### PR TITLE
check checkov and checkov.cmd as global commands

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.bridgecrewio.checkovjetbrainsidea
 pluginName = checkov-jetbrains-idea
-pluginVersion = 0.0.14
+pluginVersion = 0.0.15
 pluginSinceBuild = 201
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions

--- a/src/main/kotlin/com/bridgecrew/services/checkovService/PipCheckovService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/checkovService/PipCheckovService.kt
@@ -32,11 +32,18 @@ class PipCheckovService(val project: Project) : CheckovService {
         fun setCheckovPath(project: Project){
             // check if checkov installed globally
             isCheckovInstalledGloablly(project)
+
             // after this check, will check how to run checkov
         }
         private fun isCheckovInstalledGloablly(project: Project){
-            val cmds =arrayListOf("checkov.cmd","-v")
+            LOG.info("Checking global checkov installation with `checkov`")
+            val cmds =arrayListOf("checkov","-v")
             project.service<CliService>().run(cmds,project,::updateGlobalCheckov, ::updateGlobalCheckov)
+            if (!project.service<CliService>().isCheckovInstalledGlobally) {
+                LOG.info("Checking global checkov installation with `checkov.cmd`")
+                val cmds =arrayListOf("checkov.cmd","-v")
+                project.service<CliService>().run(cmds,project,::updateGlobalCheckov, ::updateGlobalCheckov)
+            }
         }
 
          private fun getPythonUserBasePath(project: Project) {


### PR DESCRIPTION
Updates the pip global installation logic to try both `checkov` and `checkov.cmd` to work better cross-platform.