### PR TITLE
handle "Clang" in output on some systems

### DIFF
--- a/src/main/kotlin/com/bridgecrew/CheckovResult.kt
+++ b/src/main/kotlin/com/bridgecrew/CheckovResult.kt
@@ -33,7 +33,7 @@ fun getFailedChecksFromResultString(raw: String): ArrayList<CheckovResult> {
     var checkovResult = "checkovResult"
     val outputListOfLines = raw.split("\n").map { it.trim() }
     for (i in outputListOfLines.indices) {
-        if (!outputListOfLines[i].startsWith('{') && !outputListOfLines[i].startsWith('[')){
+        if (!outputListOfLines[i].startsWith('{') && !outputListOfLines[i].startsWith('[') || outputListOfLines[i].startsWith("[Clang")){
             continue
         }
         checkovResult = outputListOfLines.subList(i,outputListOfLines.size-1).joinToString("\n")


### PR DESCRIPTION
In some cases, the first line of stdout out begins with `[Clang`, which breaks the logic to split stderr and stdout (JSON) output.