### PR TITLE
Filter out log lines with square brackets

### DIFF
--- a/src/main/kotlin/com/bridgecrew/CheckovResult.kt
+++ b/src/main/kotlin/com/bridgecrew/CheckovResult.kt
@@ -33,7 +33,9 @@ fun getFailedChecksFromResultString(raw: String): ArrayList<CheckovResult> {
     var checkovResult = "checkovResult"
     val outputListOfLines = raw.split("\n").map { it.trim() }
     for (i in outputListOfLines.indices) {
-        if (!outputListOfLines[i].startsWith('{') && !outputListOfLines[i].startsWith('[') || outputListOfLines[i].startsWith("[Clang")){
+        // filter lines that can appear in the Python version output, like '[GCC 10.2.1 20210110]'
+        if (!outputListOfLines[i].startsWith('{') && !outputListOfLines[i].startsWith('[') ||
+                (outputListOfLines[i].startsWith("[") && outputListOfLines[i].endsWith("]"))){
             continue
         }
         checkovResult = outputListOfLines.subList(i,outputListOfLines.size-1).joinToString("\n")

--- a/src/main/kotlin/com/bridgecrew/services/CheckovScanService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/CheckovScanService.kt
@@ -158,11 +158,13 @@ class CheckovScanService {
     private class ScanTask(project: Project, title: String, val filePath: String, val processHandler: ProcessHandler):
         Task.Backgroundable(project, title,true) {
         override fun run(indicator: ProgressIndicator) {
-            indicator.isIndeterminate = false
+                indicator.isIndeterminate = false
                 val output = ScriptRunnerUtil.getProcessOutput(processHandler,
                     ScriptRunnerUtil.STDOUT_OR_STDERR_OUTPUT_KEY_FILTER,
                     DEFAULT_TIMEOUT)
-            project.service<CheckovScanService>().analyzeScan(output, processHandler.exitCode!!, project, filePath)
+                LOG.info("Checkov task output:")
+                LOG.info(output)
+                project.service<CheckovScanService>().analyzeScan(output, processHandler.exitCode!!, project, filePath)
             }
         }
 


### PR DESCRIPTION
The checkov debug output produces Python version lines that may include a value like `[GCC 10.2.1 20210110]`, or `[Clang ...]`, and maybe other possibilities. The output processor thinks is the start of the checkov results object, and then breaks later on when trying to parse it. This fixes that, and also adds checkov task output to the logs, which is required for troubleshooting most issues.