### PR TITLE
override ScriptRunnerUtil.getProcessOutput to get checkov result and …

### DIFF
--- a/src/main/kotlin/com/bridgecrew/CheckovResult.kt
+++ b/src/main/kotlin/com/bridgecrew/CheckovResult.kt
@@ -30,18 +30,8 @@ fun getFailedChecksFromResultString(raw: String): ArrayList<CheckovResult> {
     if (raw.isEmpty()){
         throw CheckovResultException("Checkov result returned empty")
     }
-    var checkovResult = "checkovResult"
-    val outputListOfLines = raw.split("\n").map { it.trim() }
-    for (i in outputListOfLines.indices) {
-        // filter lines that can appear in the Python version output, like '[GCC 10.2.1 20210110]'
-        if (!outputListOfLines[i].startsWith('{') && !outputListOfLines[i].startsWith('[') ||
-                (outputListOfLines[i].startsWith("[") && outputListOfLines[i].endsWith("]"))){
-            continue
-        }
-        checkovResult = outputListOfLines.subList(i,outputListOfLines.size-1).joinToString("\n")
-        break
-    }
-    checkovResult = checkovResult.replace("\u001B[0m","")
+
+    var checkovResult = raw.replace("\u001B[0m","")
 
     return when (checkovResult[0]) {
         '{' -> getFailedChecksFromObj(JSONObject(checkovResult))

--- a/src/main/kotlin/com/bridgecrew/services/CheckovScanService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/CheckovScanService.kt
@@ -11,21 +11,21 @@ import com.bridgecrew.settings.CheckovSettingsState
 import com.bridgecrew.ui.CheckovNotificationBalloon
 import com.bridgecrew.utils.DEFAULT_TIMEOUT
 import com.bridgecrew.utils.defaultRepoName
+import com.intellij.execution.ExecutionBundle
+import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.OSProcessHandler
-import com.intellij.execution.process.ProcessHandler
-import com.intellij.execution.process.ScriptRunnerUtil
+import com.intellij.execution.process.*
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.project.Project
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
-
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
 import org.json.JSONException
 import java.nio.charset.Charset
 import javax.swing.SwingUtilities
@@ -91,23 +91,23 @@ class CheckovScanService {
         }
     }
 
-    private fun analyzeScan(result: String, errorCode: Int, project: Project, filePath: String){
-        if (result.contains("Please check your API token")) {
+    private fun analyzeScan(checkovResult: String, debugOutput: String, errorCode: Int, project: Project, filePath: String){
+        if (debugOutput.contains("Please check your API token")) {
             LOG.warn("Please check you API token\n\n" +
-                    " $result")
+                    " $debugOutput\n$checkovResult")
             project.messageBus.syncPublisher(CheckovScanListener.SCAN_TOPIC).scanningError()
             return
         }
-        if (errorCode != 0 || result.contains("[ERROR]")) {
+        if (errorCode != 0 || debugOutput.contains("[ERROR]")) {
             LOG.warn("Error scanning file\n" +
-                    "To report: open an issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues\n\n $result")
+                    "To report: open an issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues\n\n $debugOutput\n$checkovResult")
             project.messageBus.syncPublisher(CheckovScanListener.SCAN_TOPIC).scanningError()
             return
         }
         try {
             if (filePath == currentFile) {  // To show only the last run of checkov ( on the opened file)
                 val filePathRelativeToProject = filePath.replace(project.basePath!!, "")
-                val (resultsGroupedByResource, resultsLength) = getGroupedResults(result,
+                val (resultsGroupedByResource, resultsLength) = getGroupedResults(checkovResult,
                     project,
                     filePathRelativeToProject)
                 project.service<ResultsCacheService>()
@@ -122,7 +122,7 @@ class CheckovScanService {
             }
         } catch (e: JSONException) {
             LOG.warn("Error parsing checkov results \n" +
-                    "Raw response: $result\n" +
+                    "Raw response: $debugOutput\n$checkovResult\n" +
                     "To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues\n\n")
             e.printStackTrace()
             project.messageBus.syncPublisher(CheckovScanListener.SCAN_TOPIC).scanningError()
@@ -155,18 +155,45 @@ class CheckovScanService {
         return cmds
     }
 
-    private class ScanTask(project: Project, title: String, val filePath: String, val processHandler: ProcessHandler):
-        Task.Backgroundable(project, title,true) {
+    private class ScanTask(project: Project, title: String, val filePath: String, val processHandler: ProcessHandler) :
+            Task.Backgroundable(project, title, true) {
         override fun run(indicator: ProgressIndicator) {
-                indicator.isIndeterminate = false
-                val output = ScriptRunnerUtil.getProcessOutput(processHandler,
-                    ScriptRunnerUtil.STDOUT_OR_STDERR_OUTPUT_KEY_FILTER,
-                    DEFAULT_TIMEOUT)
-                LOG.info("Checkov task output:")
-                LOG.info(output)
-                project.service<CheckovScanService>().analyzeScan(output, processHandler.exitCode!!, project, filePath)
-            }
+            indicator.isIndeterminate = false
+            val processOutputs = getProcessOutputs()
+            LOG.info("Checkov task output:")
+            LOG.info(processOutputs.first + "\n" + processOutputs.second)
+            project.service<CheckovScanService>().analyzeScan(processOutputs.second, processOutputs.first, processHandler.exitCode!!, project, filePath)
         }
+
+        private fun getProcessOutputs(): Pair<String, String> {
+            LOG.assertTrue(!processHandler.isStartNotified)
+            val checkovOutputBuilder = StringBuilder()
+            val debugOutputBuilder = StringBuilder()
+            processHandler.addProcessListener(object : ProcessAdapter() {
+                override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+                    if (outputType == ProcessOutputTypes.SYSTEM) {
+                        return
+                    }
+
+                    val text = event.text
+
+                    if (outputType == ProcessOutputTypes.STDOUT) {
+                        checkovOutputBuilder.append(text)
+                    } else if (outputType == ProcessOutputTypes.STDERR) {
+                        debugOutputBuilder.append(text)
+                    }
+
+                    LOG.debug(text)
+                }
+            })
+
+            processHandler.startNotify()
+            if (!processHandler.waitFor(DEFAULT_TIMEOUT)) {
+                throw ExecutionException(ExecutionBundle.message("script.execution.timeout", (DEFAULT_TIMEOUT / 1000).toString()))
+            }
+            return Pair(debugOutputBuilder.toString(), checkovOutputBuilder.toString())
+        }
+    }
 
     private fun replaceApiToken(command: String): String {
         val apiToknIndex = command.indexOf("--bc-api-key")


### PR DESCRIPTION
We used `ScriptRunnerUtil.getProcessOutput` (a class of the official IntelliJ) after running Checkov command for getting Checkov response, and then parsed it in `CheckovResult.kt#getFailedChecksFromResultString.`

This function listens to the process, and every time the process produces new output - it appends  it to a `StringBuilder`.
The problem - we call it with the `ScriptRunnerUtil.STDOUT_OR_STDERR_OUTPUT_KEY_FILTER` parameter, so the stdout (Checkov response) and stderr (debug and higher level logs) **are appended to the same `StringBuilder`**. This means that there can be a collision between them, so the debug lines can "enter between" the Checkov response, which makes it harder for us for parsing:

The solution - overriding this function in our class, and change it so there'll be 2 `StringBuilder`s - one for checkov response and one for the logs.