### PR TITLE
BCE-14875 improve full scan

### DIFF
--- a/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
+++ b/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
@@ -114,7 +114,6 @@ class AnalyticsService(val project: Project) {
                         "framework $framework took ${formatTimeAsString(scanResults.startTime, scanResults.endTime)} minutes to be scanned\n" }
                 }\n" +
                 "full scan button pressed on ${dateFormatter.format(fullScanData!!.buttonPressedTime)}\n" +
-                "full scan button pressed on ${dateFormatter.format(fullScanData!!.buttonPressedTime)}\n" +
                 "full scan started on ${dateFormatter.format(fullScanData!!.scanStartedTime)}\n" +
                 "full scan finished on ${dateFormatter.format(fullScanData!!.scanFinishedTime)}\n" +
                 "full scan results displayed on ${dateFormatter.format(fullScanData!!.resultsWereFullyDisplayedTime)}\n"

--- a/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
+++ b/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
@@ -1,59 +1,76 @@
 package com.bridgecrew.analytics
 
+import com.bridgecrew.services.ResultsCacheService
+import com.bridgecrew.services.scan.FullScanStateService
+import com.bridgecrew.services.scan.ScanTaskResult
+import com.bridgecrew.ui.CheckovNotificationBalloon
+import com.bridgecrew.utils.DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN
+import com.bridgecrew.utils.FULL_SCAN_FRAMEWORKS
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.concurrent.TimeUnit
 
 @Service
-class AnalyticsService {
+class AnalyticsService(val project: Project) {
+
     private val LOG = logger<AnalyticsService>()
 
-    private lateinit var fullScanData: FullScanData
+    private lateinit var fullScanData: FullScanAnalyticsData
     private var fullScanNumber = 0
 
     fun fullScanButtonWasPressed() {
         val fullScanButtonWasPressedDate = Date()
         fullScanNumber += 1
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan button was pressed")
-        fullScanData = FullScanData(fullScanNumber)
-        fullScanData.fullScanButtonPressedTime = fullScanButtonWasPressedDate
+        fullScanData = FullScanAnalyticsData(fullScanNumber)
+        fullScanData.buttonPressedTime = fullScanButtonWasPressedDate
     }
 
     fun fullScanStarted() {
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan started")
-        fullScanData.fullScanStartedTime = Date()
+        fullScanData.scanStartedTime = Date()
     }
 
     fun fullScanByFrameworkStarted(framework: String) {
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan started for framework $framework")
-        fullScanData.fullScanFrameworksScanTime[framework] = FullScanFrameworkScanTimeData(Date())
+        fullScanData.frameworksScanTime[framework] = FullScanFrameworkScanTimeData(Date())
     }
 
     fun fullScanByFrameworkFinished(framework: String) {
-        fullScanData.fullScanFrameworksScanTime[framework]!!.endTime = Date()
-        fullScanData.fullScanFrameworksScanTime[framework]!!.totalTimeMinutes = fullScanData.fullScanFrameworksScanTime[framework]!!.endTime.time - fullScanData.fullScanFrameworksScanTime[framework]!!.startTime.time
-        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan finished for framework $framework and took ${fullScanData.fullScanFrameworksScanTime[framework]!!.totalTimeMinutes} ms")
+        fullScanData.frameworksScanTime[framework]!!.endTime = Date()
+        fullScanData.frameworksScanTime[framework]!!.totalTimeMinutes = fullScanData.frameworksScanTime[framework]!!.endTime.time - fullScanData.frameworksScanTime[framework]!!.startTime.time
+        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan finished for framework $framework and took ${fullScanData.frameworksScanTime[framework]!!.totalTimeMinutes} ms")
     }
 
     fun fullScanFinished() {
-        fullScanData.fullScanFinishedTime = Date()
+        fullScanData.scanFinishedTime = Date()
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan finished")
+    }
+
+    fun fullScanFrameworkFinishedNoErrors(framework: String) {
+        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - framework $framework finished with no errors")
     }
 
     fun fullScanResultsWereFullyDisplayed() {
         if (fullScanData.isFullScanFinished()) {
-            fullScanData.fullScanResultsWereFullyDisplayedTime = Date()
+            fullScanData.resultsWereFullyDisplayedTime = Date()
             LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan results are fully displayed")
             logFullScanAnalytics()
         }
-
     }
 
     fun fullScanFrameworkError(framework: String) {
-        fullScanData.fullScanFrameworkErrors.add(framework)
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - error while scanning framework $framework")
+    }
+
+    fun fullScanParsingError(framework: String, failedFiles: List<String>) {
+//        fullScanData.invalidFiles.addAll(failedFiles)
+        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - parsing error while scanning framework $framework in files ${failedFiles.joinToString { "," }}")
     }
 
     private fun logFullScanAnalytics() {
@@ -61,7 +78,7 @@ class AnalyticsService {
         var minimumScanFramework = 0L
         var maximumFramework = ""
         var minimumFramework = ""
-        fullScanData.fullScanFrameworksScanTime.forEach { framework ->
+        fullScanData.frameworksScanTime.forEach { framework ->
             if (framework.value.totalTimeMinutes >= maximumScanFramework) {
                 maximumScanFramework = framework.value.totalTimeMinutes
                 maximumFramework = framework.key
@@ -79,24 +96,25 @@ class AnalyticsService {
 
         val dateFormatter = SimpleDateFormat("dd/M/yyyy hh:mm:ss")
 
+        val frameworkScansFinishedWithErrors: MutableMap<String, ScanTaskResult> = project.service<FullScanStateService>().frameworkScansFinishedWithErrors
+
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan analytics:\n" +
-                "full scan took ${formatTimeAsString(fullScanData.fullScanButtonPressedTime, fullScanData.fullScanResultsWereFullyDisplayedTime)} minutes from pressing on the scan button to fully display the results\n" +
-                "full scan took ${formatTimeAsString(fullScanData.fullScanStartedTime, fullScanData.fullScanFinishedTime)} minutes from starting checkov scans and finishing checkov scans for all frameworks\n" +
-                "full scan took ${formatTimeAsString(fullScanData.fullScanButtonPressedTime, fullScanData.fullScanStartedTime)} minutes from pressing on the scan button to starting checkov scan\n" +
-                "full scan took ${formatTimeAsString(fullScanData.fullScanFinishedTime, fullScanData.fullScanResultsWereFullyDisplayedTime)} minutes from finishing checkov scans for all frameworks to fully display the results\n" +
-                "framework scan $maximumFramework took the most - ${formatTimeAsString(fullScanData.fullScanFrameworksScanTime[maximumFramework]!!.startTime, fullScanData.fullScanFrameworksScanTime[maximumFramework]!!.endTime)} minutes\n" +
-                "framework scan $minimumFramework took the least - ${formatTimeAsString(fullScanData.fullScanFrameworksScanTime[minimumFramework]!!.startTime, fullScanData.fullScanFrameworksScanTime[minimumFramework]!!.endTime)} minutes\n" +
-                "${fullScanData.fullScanFrameworkErrors.size} frameworks was finished with errors: ${fullScanData.fullScanFrameworkErrors}\n" +
-                "frameworks scans:\n ${
-                    fullScanData.fullScanFrameworksScanTime.map { framework ->
-                        "framework ${framework.key} took ${formatTimeAsString(framework.value.startTime, framework.value.endTime)} minutes to be scanned\n"
-                    }
+                "full scan took ${formatTimeAsString(fullScanData.buttonPressedTime, fullScanData.resultsWereFullyDisplayedTime)} minutes from pressing on the scan button to fully display the results\n" +
+                "full scan took ${formatTimeAsString(fullScanData.scanStartedTime, fullScanData.scanFinishedTime)} minutes from starting checkov scans and finishing checkov scans for all frameworks\n" +
+                "full scan took ${formatTimeAsString(fullScanData.buttonPressedTime, fullScanData.scanStartedTime)} minutes from pressing on the scan button to starting checkov scan\n" +
+                "full scan took ${formatTimeAsString(fullScanData.scanFinishedTime, fullScanData.resultsWereFullyDisplayedTime)} minutes from finishing checkov scans for all frameworks to fully display the results\n" +
+                "framework scan $maximumFramework took the most - ${formatTimeAsString(fullScanData.frameworksScanTime[maximumFramework]!!.startTime, fullScanData.frameworksScanTime[maximumFramework]!!.endTime)} minutes\n" +
+                "framework scan $minimumFramework took the least - ${formatTimeAsString(fullScanData.frameworksScanTime[minimumFramework]!!.startTime, fullScanData.frameworksScanTime[minimumFramework]!!.endTime)} minutes\n" +
+                "${frameworkScansFinishedWithErrors.size} frameworks was finished with errors: ${frameworkScansFinishedWithErrors.keys}\n" +
+                "frameworks scans:\n" +
+                "${fullScanData.frameworksScanTime.map { (framework, scanResults) ->
+                        "framework $framework took ${formatTimeAsString(scanResults.startTime, scanResults.endTime)} minutes to be scanned\n" }
                 }\n" +
-                "full scan button pressed on ${dateFormatter.format(fullScanData.fullScanButtonPressedTime)}\n" +
-                "full scan button pressed on ${dateFormatter.format(fullScanData.fullScanButtonPressedTime)}\n" +
-                "full scan started on ${dateFormatter.format(fullScanData.fullScanStartedTime)}\n" +
-                "full scan finished on ${dateFormatter.format(fullScanData.fullScanFinishedTime)}\n" +
-                "full scan results displayed on ${dateFormatter.format(fullScanData.fullScanResultsWereFullyDisplayedTime)}\n"
+                "full scan button pressed on ${dateFormatter.format(fullScanData.buttonPressedTime)}\n" +
+                "full scan button pressed on ${dateFormatter.format(fullScanData.buttonPressedTime)}\n" +
+                "full scan started on ${dateFormatter.format(fullScanData.scanStartedTime)}\n" +
+                "full scan finished on ${dateFormatter.format(fullScanData.scanFinishedTime)}\n" +
+                "full scan results displayed on ${dateFormatter.format(fullScanData.resultsWereFullyDisplayedTime)}\n"
         )
     }
 
@@ -109,17 +127,19 @@ class AnalyticsService {
         return "${minutes}:${secondsString}"
     }
 
-    data class FullScanData(val scanNumber: Int) {
-        lateinit var fullScanButtonPressedTime: Date
-        lateinit var fullScanStartedTime: Date
-        val fullScanFrameworksScanTime: MutableMap<String, FullScanFrameworkScanTimeData> = mutableMapOf()
-        lateinit var fullScanFinishedTime: Date
-        lateinit var fullScanResultsWereFullyDisplayedTime: Date
-        val fullScanFrameworkErrors = mutableSetOf<String>()
+    data class FullScanAnalyticsData(val scanNumber: Int) {
+        lateinit var buttonPressedTime: Date
+        lateinit var scanStartedTime: Date
+        val frameworksScanTime: MutableMap<String, FullScanFrameworkScanTimeData> = mutableMapOf()
+        lateinit var scanFinishedTime: Date
+        lateinit var resultsWereFullyDisplayedTime: Date
+//        val frameworkScansFinishedWithErrors = mutableMapOf<String, ScanTaskResult>()
+//        val invalidFiles = mutableSetOf<String>()
+//        val frameworkScamsFinishedWithNoVulnerabilities = mutableSetOf<String>()
 
-        fun isFullScanFinished() = ::fullScanFinishedTime.isInitialized
+        fun isFullScanFinished() = ::scanFinishedTime.isInitialized
     }
-
+//
     data class FullScanFrameworkScanTimeData(val startTime: Date) {
         var endTime: Date = Date()
         var totalTimeMinutes = 0L

--- a/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
+++ b/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
@@ -72,12 +72,7 @@ class AnalyticsService(val project: Project) {
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - $numberOfVulnerabilities security issues were detected while scanning framework $framework")
     }
 
-//    fun updateScanTotalFiles(passedFiles: Int, failedFiles: Int) {
-//        fullScanData.totalPassed += passedFiles
-//        fullScanData.totalFailed += failedFiles
-//    }
     fun fullScanParsingError(framework: String, failedFilesSize: Int) {
-//        fullScanData.invalidFiles.addAll(failedFiles)
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - parsing error while scanning framework $framework in $failedFilesSize files}")
     }
 
@@ -141,18 +136,10 @@ class AnalyticsService(val project: Project) {
         val frameworksScanTime: MutableMap<String, FullScanFrameworkScanTimeData> = mutableMapOf()
         lateinit var scanFinishedTime: Date
         lateinit var resultsWereFullyDisplayedTime: Date
-//        val frameworkScansFinishedWithErrors = mutableMapOf<String, ScanTaskResult>()
-//        val invalidFiles = mutableSetOf<String>()
-//        val frameworkScamsFinishedWithNoVulnerabilities = mutableSetOf<String>()
 
         fun isFullScanFinished() = ::scanFinishedTime.isInitialized
         fun isFullScanStarted() = ::scanStartedTime.isInitialized
     }
-//
-
-//    fun getFullScanData(): FullScanData? {
-//        return if(this::fullScanData.isInitialized) this.fullScanData else null
-//    }
 
     data class FullScanFrameworkScanTimeData(val startTime: Date) {
         var endTime: Date = Date()

--- a/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
+++ b/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
@@ -68,13 +68,17 @@ class AnalyticsService(val project: Project) {
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - error while scanning framework $framework")
     }
 
+    fun fullScanFrameworkDetectedVulnerabilities(framework: String, numberOfVulnerabilities: Int) {
+        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - $numberOfVulnerabilities security issues were detected while scanning framework $framework")
+    }
+
 //    fun updateScanTotalFiles(passedFiles: Int, failedFiles: Int) {
 //        fullScanData.totalPassed += passedFiles
 //        fullScanData.totalFailed += failedFiles
 //    }
-    fun fullScanParsingError(framework: String, failedFiles: List<String>) {
+    fun fullScanParsingError(framework: String, failedFilesSize: Int) {
 //        fullScanData.invalidFiles.addAll(failedFiles)
-        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - parsing error while scanning framework $framework in files ${failedFiles.joinToString { "," }}")
+        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - parsing error while scanning framework $framework in $failedFilesSize files}")
     }
 
     private fun logFullScanAnalytics() {

--- a/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
+++ b/src/main/kotlin/com/bridgecrew/analytics/AnalyticsService.kt
@@ -20,7 +20,7 @@ class AnalyticsService(val project: Project) {
 
     private val LOG = logger<AnalyticsService>()
 
-    private lateinit var fullScanData: FullScanAnalyticsData
+    var fullScanData: FullScanAnalyticsData? = null
     private var fullScanNumber = 0
 
     fun fullScanButtonWasPressed() {
@@ -28,27 +28,27 @@ class AnalyticsService(val project: Project) {
         fullScanNumber += 1
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan button was pressed")
         fullScanData = FullScanAnalyticsData(fullScanNumber)
-        fullScanData.buttonPressedTime = fullScanButtonWasPressedDate
+        fullScanData!!.buttonPressedTime = fullScanButtonWasPressedDate
     }
 
     fun fullScanStarted() {
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan started")
-        fullScanData.scanStartedTime = Date()
+        fullScanData!!.scanStartedTime = Date()
     }
 
     fun fullScanByFrameworkStarted(framework: String) {
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan started for framework $framework")
-        fullScanData.frameworksScanTime[framework] = FullScanFrameworkScanTimeData(Date())
+        fullScanData!!.frameworksScanTime[framework] = FullScanFrameworkScanTimeData(Date())
     }
 
     fun fullScanByFrameworkFinished(framework: String) {
-        fullScanData.frameworksScanTime[framework]!!.endTime = Date()
-        fullScanData.frameworksScanTime[framework]!!.totalTimeMinutes = fullScanData.frameworksScanTime[framework]!!.endTime.time - fullScanData.frameworksScanTime[framework]!!.startTime.time
-        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan finished for framework $framework and took ${fullScanData.frameworksScanTime[framework]!!.totalTimeMinutes} ms")
+        fullScanData!!.frameworksScanTime[framework]!!.endTime = Date()
+        fullScanData!!.frameworksScanTime[framework]!!.totalTimeMinutes = fullScanData!!.frameworksScanTime[framework]!!.endTime.time - fullScanData!!.frameworksScanTime[framework]!!.startTime.time
+        LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan finished for framework $framework and took ${fullScanData!!.frameworksScanTime[framework]!!.totalTimeMinutes} ms")
     }
 
     fun fullScanFinished() {
-        fullScanData.scanFinishedTime = Date()
+        fullScanData!!.scanFinishedTime = Date()
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan finished")
     }
 
@@ -57,8 +57,8 @@ class AnalyticsService(val project: Project) {
     }
 
     fun fullScanResultsWereFullyDisplayed() {
-        if (fullScanData.isFullScanFinished()) {
-            fullScanData.resultsWereFullyDisplayedTime = Date()
+        if (fullScanData!!.isFullScanFinished()) {
+            fullScanData!!.resultsWereFullyDisplayedTime = Date()
             LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan results are fully displayed")
             logFullScanAnalytics()
         }
@@ -68,10 +68,10 @@ class AnalyticsService(val project: Project) {
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - error while scanning framework $framework")
     }
 
-    fun updateScanTotalFiles(passedFiles: Int, failedFiles: Int) {
-        fullScanData.totalPassed += passedFiles
-        fullScanData.totalFailed += failedFiles
-    }
+//    fun updateScanTotalFiles(passedFiles: Int, failedFiles: Int) {
+//        fullScanData.totalPassed += passedFiles
+//        fullScanData.totalFailed += failedFiles
+//    }
     fun fullScanParsingError(framework: String, failedFiles: List<String>) {
 //        fullScanData.invalidFiles.addAll(failedFiles)
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - parsing error while scanning framework $framework in files ${failedFiles.joinToString { "," }}")
@@ -82,7 +82,7 @@ class AnalyticsService(val project: Project) {
         var minimumScanFramework = 0L
         var maximumFramework = ""
         var minimumFramework = ""
-        fullScanData.frameworksScanTime.forEach { framework ->
+        fullScanData!!.frameworksScanTime.forEach { framework ->
             if (framework.value.totalTimeMinutes >= maximumScanFramework) {
                 maximumScanFramework = framework.value.totalTimeMinutes
                 maximumFramework = framework.key
@@ -103,22 +103,22 @@ class AnalyticsService(val project: Project) {
         val frameworkScansFinishedWithErrors: MutableMap<String, ScanTaskResult> = project.service<FullScanStateService>().frameworkScansFinishedWithErrors
 
         LOG.info("Prisma Plugin Analytics - scan #${fullScanNumber} - full scan analytics:\n" +
-                "full scan took ${formatTimeAsString(fullScanData.buttonPressedTime, fullScanData.resultsWereFullyDisplayedTime)} minutes from pressing on the scan button to fully display the results\n" +
-                "full scan took ${formatTimeAsString(fullScanData.scanStartedTime, fullScanData.scanFinishedTime)} minutes from starting checkov scans and finishing checkov scans for all frameworks\n" +
-                "full scan took ${formatTimeAsString(fullScanData.buttonPressedTime, fullScanData.scanStartedTime)} minutes from pressing on the scan button to starting checkov scan\n" +
-                "full scan took ${formatTimeAsString(fullScanData.scanFinishedTime, fullScanData.resultsWereFullyDisplayedTime)} minutes from finishing checkov scans for all frameworks to fully display the results\n" +
-                "framework scan $maximumFramework took the most - ${formatTimeAsString(fullScanData.frameworksScanTime[maximumFramework]!!.startTime, fullScanData.frameworksScanTime[maximumFramework]!!.endTime)} minutes\n" +
-                "framework scan $minimumFramework took the least - ${formatTimeAsString(fullScanData.frameworksScanTime[minimumFramework]!!.startTime, fullScanData.frameworksScanTime[minimumFramework]!!.endTime)} minutes\n" +
+                "full scan took ${formatTimeAsString(fullScanData!!.buttonPressedTime, fullScanData!!.resultsWereFullyDisplayedTime)} minutes from pressing on the scan button to fully display the results\n" +
+                "full scan took ${formatTimeAsString(fullScanData!!.scanStartedTime, fullScanData!!.scanFinishedTime)} minutes from starting checkov scans and finishing checkov scans for all frameworks\n" +
+                "full scan took ${formatTimeAsString(fullScanData!!.buttonPressedTime, fullScanData!!.scanStartedTime)} minutes from pressing on the scan button to starting checkov scan\n" +
+                "full scan took ${formatTimeAsString(fullScanData!!.scanFinishedTime, fullScanData!!.resultsWereFullyDisplayedTime)} minutes from finishing checkov scans for all frameworks to fully display the results\n" +
+                "framework scan $maximumFramework took the most - ${formatTimeAsString(fullScanData!!.frameworksScanTime[maximumFramework]!!.startTime, fullScanData!!.frameworksScanTime[maximumFramework]!!.endTime)} minutes\n" +
+                "framework scan $minimumFramework took the least - ${formatTimeAsString(fullScanData!!.frameworksScanTime[minimumFramework]!!.startTime, fullScanData!!.frameworksScanTime[minimumFramework]!!.endTime)} minutes\n" +
                 "${frameworkScansFinishedWithErrors.size} frameworks was finished with errors: ${frameworkScansFinishedWithErrors.keys}\n" +
                 "frameworks scans:\n" +
-                "${fullScanData.frameworksScanTime.map { (framework, scanResults) ->
+                "${fullScanData!!.frameworksScanTime.map { (framework, scanResults) ->
                         "framework $framework took ${formatTimeAsString(scanResults.startTime, scanResults.endTime)} minutes to be scanned\n" }
                 }\n" +
-                "full scan button pressed on ${dateFormatter.format(fullScanData.buttonPressedTime)}\n" +
-                "full scan button pressed on ${dateFormatter.format(fullScanData.buttonPressedTime)}\n" +
-                "full scan started on ${dateFormatter.format(fullScanData.scanStartedTime)}\n" +
-                "full scan finished on ${dateFormatter.format(fullScanData.scanFinishedTime)}\n" +
-                "full scan results displayed on ${dateFormatter.format(fullScanData.resultsWereFullyDisplayedTime)}\n"
+                "full scan button pressed on ${dateFormatter.format(fullScanData!!.buttonPressedTime)}\n" +
+                "full scan button pressed on ${dateFormatter.format(fullScanData!!.buttonPressedTime)}\n" +
+                "full scan started on ${dateFormatter.format(fullScanData!!.scanStartedTime)}\n" +
+                "full scan finished on ${dateFormatter.format(fullScanData!!.scanFinishedTime)}\n" +
+                "full scan results displayed on ${dateFormatter.format(fullScanData!!.resultsWereFullyDisplayedTime)}\n"
         )
     }
 
@@ -137,20 +137,18 @@ class AnalyticsService(val project: Project) {
         val frameworksScanTime: MutableMap<String, FullScanFrameworkScanTimeData> = mutableMapOf()
         lateinit var scanFinishedTime: Date
         lateinit var resultsWereFullyDisplayedTime: Date
-        var totalPassed: Int = 0
-        var totalFailed: Int = 0
 //        val frameworkScansFinishedWithErrors = mutableMapOf<String, ScanTaskResult>()
 //        val invalidFiles = mutableSetOf<String>()
 //        val frameworkScamsFinishedWithNoVulnerabilities = mutableSetOf<String>()
 
         fun isFullScanFinished() = ::scanFinishedTime.isInitialized
-        fun isFullScanStarted() = ::fullScanStartedTime.isInitialized
+        fun isFullScanStarted() = ::scanStartedTime.isInitialized
     }
 //
 
-    fun getFullScanData(): FullScanData? {
-        return if(this::fullScanData.isInitialized) this.fullScanData else null
-    }
+//    fun getFullScanData(): FullScanData? {
+//        return if(this::fullScanData.isInitialized) this.fullScanData else null
+//    }
 
     data class FullScanFrameworkScanTimeData(val startTime: Date) {
         var endTime: Date = Date()

--- a/src/main/kotlin/com/bridgecrew/errors/CheckovErrorHandler.kt
+++ b/src/main/kotlin/com/bridgecrew/errors/CheckovErrorHandler.kt
@@ -15,106 +15,62 @@ import java.nio.charset.Charset
 import java.nio.file.Files
 import kotlin.io.path.Path
 import com.bridgecrew.analytics.AnalyticsService
+import com.bridgecrew.services.scan.ScanTaskResult
 import com.intellij.openapi.components.service
 
 @Service
 class CheckovErrorHandlerService(val project: Project) {
     private val LOG = logger<CheckovErrorHandlerService>()
 
-    private fun saveErrorResultToFile(result: String, dataSourceKey: String, dataSourceValue: String, dataSourceDirName: String, error: Exception, scanSourceType: CheckovScanService.ScanSourceType) {
+    private fun saveErrorResultToFile(scanTaskResult: ScanTaskResult, dataSourceKey: String, dataSourceValue: String, dataSourceDirName: String, error: Exception, scanSourceType: CheckovScanService.ScanSourceType) {
 
         val errorMessage = if (error.message != null) {
-            "Error while scanning $dataSourceValue, original error message - ${error.message}"
+            "Error while scanning ${scanSourceType.toString().lowercase()} ${dataSourceValue.replace(project.basePath!!, "")}, original error message - ${error.message}"
         } else "Error while scanning $dataSourceValue"
 
-        var errorFilePath = ""
-        try {
-            val json = JSONObject()
+        LOG.error("${errorMessage}. Please check the log file in ${scanTaskResult.debugOutput.path}. Checkov result can be found in ${scanTaskResult.checkovResult.path}. To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues\n\n")
 
-            json.put(dataSourceKey, dataSourceValue)
-            json.put("error", error)
-            json.put("error_message", error.message)
-            json.put("checkov_result", result)
-
-            val errorFileDirectoryPath = "${project.basePath!!}/${ERROR_LOG_DIR_PATH}/${dataSourceDirName}"
-            Files.createDirectories(Path(errorFileDirectoryPath))
-
-            errorFilePath = "$errorFileDirectoryPath/${System.currentTimeMillis()}.json"
-
-            PrintWriter(FileWriter(errorFilePath, Charset.defaultCharset()))
-                    .use { it.write(json.toString()) }
-            LOG.error("${errorMessage}\n, please check the log file in $errorFilePath. To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues\n\n")
-        } catch (e: Exception) {
-            logCheckovResult(result, "${errorMessage}\n, error reason - ${e.message}.")
-            e.printStackTrace()
-        }
-
-        CheckovNotificationBalloon.showNotification(project, "Error while running Checkov scan on ${scanSourceType.toString().lowercase()} ${dataSourceValue.replace(project.basePath!!, "")}, please check the log file in $errorFilePath. To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues", NotificationType.ERROR)
-
+        CheckovNotificationBalloon.showNotification(project, "Error while running Checkov scan on ${scanSourceType.toString().lowercase()} ${dataSourceValue.replace(project.basePath!!, "")}, please check the debug log file in ${scanTaskResult.debugOutput.path}, Checkov result can be found in ${scanTaskResult.checkovResult.path}. To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues", NotificationType.ERROR)
     }
 
-    private fun saveParsingErrorResultToFile(result: String, dataSourceKey: String, dataSourceValue: String, dataSourceDirName: String, failedFiles: List<String>, scanSourceType: CheckovScanService.ScanSourceType) {
-        val json = JSONObject()
+    private fun saveParsingErrorResultToFile(scanTaskResult: ScanTaskResult, dataSourceKey: String, dataSourceValue: String, dataSourceDirName: String, failedFiles: List<String>, scanSourceType: CheckovScanService.ScanSourceType) {
         var errorFilePath = ""
-        try {
-            json.put(dataSourceKey, dataSourceValue)
-            json.put("failed_files", failedFiles)
-            json.put("checkov_result", result)
 
-
-            val errorFileDirectoryPath = "${project.basePath!!}/${ERROR_LOG_DIR_PATH}/${dataSourceDirName}/parsingErrors"
-            Files.createDirectories(Path(errorFileDirectoryPath))
-
-            errorFilePath = "${errorFileDirectoryPath}/${System.currentTimeMillis()}.json"
-
-            PrintWriter(FileWriter(errorFilePath, Charset.defaultCharset()))
-                    .use { it.write(json.toString()) }
-            LOG.error("Error while parsing result while scanning ${dataSourceValue.replace(project.basePath!!, "")} for files ${failedFiles}, please check the log file in $errorFilePath. To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues\n\n")
-
-        } catch (e: Exception) {
-            logCheckovResult(result, "Error while parsing result for ${scanSourceType.toString().lowercase()} ${dataSourceValue.replace(project.basePath!!, "")} - error files ${failedFiles}. Failed files - ${failedFiles}.")
-            e.printStackTrace()
-        }
+        LOG.error("Error while parsing result while scanning ${scanSourceType.toString().lowercase()} ${dataSourceValue.replace(project.basePath!!, "")} for files $failedFiles" +
+                "Please check the log file in ${scanTaskResult.debugOutput.path}. Checkov result can be found in ${scanTaskResult.checkovResult.path}. To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues\n\n")
 
         CheckovNotificationBalloon.showNotification(project, "Parsing error while scanning ${scanSourceType.toString().lowercase()} ${dataSourceValue.replace(project.basePath!!, "")}, please check the log file in $errorFilePath. To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues", NotificationType.ERROR)
     }
 
-    fun scanningParsingError(result: String, source: String, failedFiles: List<String>, scanSourceType: CheckovScanService.ScanSourceType) {
+    fun scanningParsingError(scanTaskResult: ScanTaskResult, source: String, failedFiles: List<String>, scanSourceType: CheckovScanService.ScanSourceType) {
 
         when (scanSourceType) {
             CheckovScanService.ScanSourceType.FILE -> {
-                saveParsingErrorResultToFile(result, "file_path", source, extractFileNameFromPath(source), failedFiles, scanSourceType)
+                saveParsingErrorResultToFile(scanTaskResult, "file_path", source, extractFileNameFromPath(source), failedFiles, scanSourceType)
             }
 
             CheckovScanService.ScanSourceType.FRAMEWORK -> {
-                saveParsingErrorResultToFile(result, "framework", source, source, failedFiles, scanSourceType)
+                saveParsingErrorResultToFile(scanTaskResult, "framework", source, source, failedFiles, scanSourceType)
                 project.service<AnalyticsService>().fullScanFrameworkError(source)
             }
         }
 
     }
 
-    fun scanningError(result: String, source: String, error: Exception, scanSourceType: CheckovScanService.ScanSourceType) {
+    fun scanningError(scanTaskResult: ScanTaskResult, source: String, error: Exception, scanSourceType: CheckovScanService.ScanSourceType) {
 
         when (scanSourceType) {
             CheckovScanService.ScanSourceType.FILE -> {
-                saveErrorResultToFile(result, "file_path", source, extractFileNameFromPath(source), error, scanSourceType)
+                saveErrorResultToFile(scanTaskResult, "file_path", source, extractFileNameFromPath(source), error, scanSourceType)
             }
 
             CheckovScanService.ScanSourceType.FRAMEWORK -> {
-                saveErrorResultToFile(result, "framework", source, source, error, scanSourceType)
+                saveErrorResultToFile(scanTaskResult, "framework", source, source, error, scanSourceType)
                 project.service<AnalyticsService>().fullScanFrameworkError(source)
 
             }
         }
 
-    }
-
-    private fun logCheckovResult(result: String, errorMessage: String) {
-        LOG.error("$errorMessage\n. Checkov result: \n" +
-                "------------------------------------------\n" +
-                result.substring((result.length - 1000).coerceAtLeast(0)) +
-                "\n------------------------------------------\n\n")
     }
 
 }

--- a/src/main/kotlin/com/bridgecrew/errors/CheckovErrorHandler.kt
+++ b/src/main/kotlin/com/bridgecrew/errors/CheckovErrorHandler.kt
@@ -24,7 +24,7 @@ class CheckovErrorHandlerService(val project: Project) {
                 "Checkov result can be found in ${scanTaskResult.checkovResult.path}.\n" +
                 "To report: open a issue at https://github.com/bridgecrewio/checkov-jetbrains-ide/issues\n"
 
-        LOG.warn(errorMessage)
+        LOG.error(errorMessage)
 
         CheckovNotificationBalloon.showNotification(project,
                 errorMessage,

--- a/src/main/kotlin/com/bridgecrew/errors/CheckovErrorHandler.kt
+++ b/src/main/kotlin/com/bridgecrew/errors/CheckovErrorHandler.kt
@@ -2,7 +2,7 @@ package com.bridgecrew.errors
 
 import com.bridgecrew.services.scan.CheckovScanService
 import com.bridgecrew.ui.CheckovNotificationBalloon
-import com.bridgecrew.utils.ERROR_LOG_DIR_PATH
+//import com.bridgecrew.utils.ERROR_LOG_DIR_PATH
 import com.bridgecrew.utils.extractFileNameFromPath
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.Service
@@ -24,8 +24,7 @@ class CheckovErrorHandlerService(val project: Project) {
     private val LOG = logger<CheckovErrorHandlerService>()
 
     fun notifyAboutScanError(scanTaskResult: ScanTaskResult, dataSourceValue: String, error: Exception, scanSourceType: CheckovScanService.ScanSourceType) {
-
-        var errorMessagePrefix = if (error.message != null) {
+        val errorMessagePrefix = if (error.message != null) {
             "Error while scanning ${scanSourceType.toString().lowercase()} ${dataSourceValue.replace(project.basePath!!, "")}, original error message - ${error.message}"
         } else "Error while scanning $dataSourceValue"
 

--- a/src/main/kotlin/com/bridgecrew/errors/CheckovErrorHandler.kt
+++ b/src/main/kotlin/com/bridgecrew/errors/CheckovErrorHandler.kt
@@ -2,19 +2,10 @@ package com.bridgecrew.errors
 
 import com.bridgecrew.services.scan.CheckovScanService
 import com.bridgecrew.ui.CheckovNotificationBalloon
-//import com.bridgecrew.utils.ERROR_LOG_DIR_PATH
-import com.bridgecrew.utils.extractFileNameFromPath
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import org.json.JSONObject
-import java.io.FileWriter
-import java.io.PrintWriter
-import java.nio.charset.Charset
-import java.nio.file.Files
-import kotlin.io.path.Path
-import com.bridgecrew.analytics.AnalyticsService
 import com.bridgecrew.services.scan.FullScanStateService
 import com.bridgecrew.services.scan.ScanTaskResult
 import com.intellij.openapi.components.service
@@ -49,21 +40,6 @@ class CheckovErrorHandlerService(val project: Project) {
                 errorMessage,
                 NotificationType.WARNING)
     }
-
-//    fun scanningParsingError(scanTaskResult: ScanTaskResult, source: String, failedFiles: List<String>) {
-//
-//        when (scanSourceType) {
-//            CheckovScanService.ScanSourceType.FILE -> {
-//                saveParsingErrorResultToFile(scanTaskResult, source, failedFiles, scanSourceType)
-//            }
-//
-////            CheckovScanService.ScanSourceType.FRAMEWORK -> {
-////                saveParsingErrorResultToFile(scanTaskResult, source, failedFiles, scanSourceType)
-////                project.service<FullScanStateService>().parsingErrorsFoundInFiles(source, failedFiles)
-////            }
-//        }
-//
-//    }
 
     fun scanningError(scanTaskResult: ScanTaskResult, source: String, error: Exception, scanSourceType: CheckovScanService.ScanSourceType) {
 

--- a/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/CheckovScanCommandsService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/CheckovScanCommandsService.kt
@@ -54,7 +54,7 @@ abstract class CheckovScanCommandsService(val project: Project) {
                     "Please insert an Api Token to continue")
         }
 
-        return arrayListOf("-s", "--bc-api-key", apiToken, "--repo-id", gitRepo, "-o", "json")
+        return arrayListOf("-s", "--bc-api-key", apiToken, "--repo-id", gitRepo, "--quiet", "-o", "json")
     }
 
     private fun getExcludePathCommand(): ArrayList<String> {

--- a/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/DockerCheckovScanCommandsService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/DockerCheckovScanCommandsService.kt
@@ -14,7 +14,7 @@ class DockerCheckovScanCommandsService(project: Project) : CheckovScanCommandsSe
                 PluginManagerCore.getPlugin(PluginId.getId("com.github.bridgecrewio.checkov"))?.version ?: "UNKNOWN"
 
         val volumeDir = "${FilenameUtils.separatorsToUnix(project.basePath!!)}:/${volumeDirectory}"
-        val dockerCommand = arrayListOf("docker", "run", "--rm", "--tty", "--env", "BC_SOURCE=jetbrains", "--env", "BC_SOURCE_VERSION=$pluginVersion", "--env", "LOG_LEVEL=DEBUG")
+        val dockerCommand = arrayListOf("docker", "run", "--rm", "-a", "stdout", "-a", "stderr", "--env", "BC_SOURCE=jetbrains", "--env", "BC_SOURCE_VERSION=$pluginVersion", "--env", "LOG_LEVEL=DEBUG")
         val prismaUrl = settings?.prismaURL
         if (!prismaUrl.isNullOrEmpty()) {
             dockerCommand.addAll(arrayListOf("--env", "PRISMA_API_URL=${prismaUrl}"))

--- a/src/main/kotlin/com/bridgecrew/services/scan/CheckovScanService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/CheckovScanService.kt
@@ -309,6 +309,17 @@ class CheckovScanService {
             LOG.error("Please check you API token\n\n")
             return false
         }
+
+        if (scanTaskResult.errorReason.contains("missing dependencies (e.g., helm or kustomize, which require those tools to be on your system")) {
+            val errorMessage = "Framework $scanningSource was not scanned since it's probably not installed: ${scanTaskResult.errorReason}"
+            LOG.warn(errorMessage)
+            scanTaskResult.checkovResult.delete()
+            scanTaskResult.debugOutput.delete()
+            project.service<FullScanStateService>().frameworkWasNotScanned(scanningSource)
+            return false
+
+        }
+
         if (errorCode != 0 || scanTaskResult.errorReason.isNotEmpty()) {
             project.service<CheckovErrorHandlerService>().scanningError(scanTaskResult, scanningSource, Exception("Error while scanning $scanningSource, exit code - $errorCode, error reason - ${scanTaskResult.errorReason}"), scanSourceType)
             return false

--- a/src/main/kotlin/com/bridgecrew/services/scan/CheckovScanService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/CheckovScanService.kt
@@ -238,69 +238,6 @@ class CheckovScanService {
             project.service<CheckovErrorHandlerService>().scanningError(scanTaskResult, filePath, error, ScanSourceType.FILE)
         }
     }
-//    fun analyzeScan(scanTaskResult: ScanTaskResult, errorCode: Int, project: Project, scanningSource: String, scanSourceType: ScanSourceType) {
-//        if (!isValidScanResults(scanTaskResult, errorCode, scanningSource, scanSourceType, project)) {
-//            return
-//        }
-//
-//        try {
-//            val extractionResult: CheckovResultExtractionData = CheckovUtils.extractFailedChecksAndParsingErrorsFromCheckovResult(scanTaskResult.checkovResult.readText(), scanningSource)
-//
-//            if (extractionResult.parsingErrors.isNotEmpty()) {
-//                project.service<CheckovErrorHandlerService>().scanningParsingError(scanTaskResult, scanningSource, extractionResult.parsingErrors, scanSourceType)
-//            }
-//
-//            if (!isScanFinishedWithoutErrors(extractionResult, scanSourceType, scanningSource, project)) {
-//                project.service<ResultsCacheService>().addCheckovResults(extractionResult.failedChecks)
-//                LOG.info("Checkov scanning finished for ${scanSourceType.toString().lowercase()}: ${scanningSource.replace(project.basePath!!, "")}, ${extractionResult.parsingErrors.size} errors have been detected in $scanningSource")
-////            CheckovNotificationBalloon.showNotification(project, "Checkov scanning finished for ${scanSourceType.toString().lowercase()}: ${scanningSource.replace(project.basePath!!, "")}, please check the results panel.", NotificationType.INFORMATION)
-//                project.messageBus.syncPublisher(CheckovScanListener.SCAN_TOPIC).scanningFinished(scanSourceType)
-//
-//                if (scanSourceType == ScanSourceType.FRAMEWORK)
-//                    project.service<FullScanStateService>().frameworkScanFinishedAndDetectedIssues()
-//            }
-//
-////            if ( dextractionResult.failedChecks.isEmpty()) {
-////                if (extractionResult.parsingErrors.isEmpty()) {
-//////                    CheckovNotificationBalloon.showNotification(project, "Checkov scanning finished, no errors have been detected for ${scanSourceType.toString().lowercase()}: $scanningSource", NotificationType.INFORMATION)
-////                    LOG.info("Checkov scanning finished, no errors have been detected for ${scanSourceType.toString().lowercase()}: ${scanningSource.replace(project.basePath!!, "")}")
-////                    project.service<FullScanStateService>().frameworkFinishedWithNoErrors(scanningSource)
-////
-////                }
-////                scanTaskResult.checkovResult.delete()
-////                scanTaskResult.debugOutput.delete()
-////                return
-////            }
-//
-//
-//            project.service<FullScanStateService>().totalPassedCheckovChecks += extractionResult.passedChecksSize
-//            project.service<FullScanStateService>().totalFailedCheckovChecks += extractionResult.failedChecks.size
-//            scanTaskResult.checkovResult.delete()
-//            scanTaskResult.debugOutput.delete()
-//
-//        } catch (error: Exception) {
-//            LOG.warn("Error while analyzing scan results for ${scanSourceType.toString().lowercase()} $scanningSource")
-//            project.service<CheckovErrorHandlerService>().scanningError(scanTaskResult, scanningSource, error, scanSourceType)
-//        }
-//    }
-
-
-//    private fun isScanFinishedWithoutErrors(extractionResult: CheckovResultExtractionData, scanSourceType: ScanSourceType, scanningSource: String, project: Project): Boolean {
-//        if (extractionResult.failedChecks.isNotEmpty()) {
-//            return false
-//        }
-//
-//        if (extractionResult.parsingErrors.isEmpty()) {
-////                    CheckovNotificationBalloon.showNotification(project, "Checkov scanning finished, no errors have been detected for ${scanSourceType.toString().lowercase()}: $scanningSource", NotificationType.INFORMATION)
-//            LOG.info("Checkov scanning finished, no errors have been detected for ${scanSourceType.toString().lowercase()}: ${scanningSource.replace(project.basePath!!, "")}")
-//
-//            if (scanSourceType == ScanSourceType.FRAMEWORK)
-//                project.service<FullScanStateService>().frameworkFinishedWithNoErrors(scanningSource)
-//
-//        }
-//
-//        return true
-//    }
 
     private fun isValidScanResults(scanTaskResult: ScanTaskResult, errorCode: Int, scanningSource: String, scanSourceType: ScanSourceType, project: Project): Boolean {
         if (scanTaskResult.errorReason.contains("Please check your API token")) {

--- a/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
@@ -24,6 +24,7 @@ class FullScanStateService(val project: Project) {
     var frameworkScansFinishedWithErrors = mutableMapOf<String, ScanTaskResult>()
     var invalidFilesSize: Int = 0
     var frameworkScansFinishedWithNoVulnerabilities = mutableSetOf<String>()
+    var unscannedFrameworks = mutableSetOf<String>()
     var totalPassedCheckovChecks: Int = 0
     var totalFailedCheckovChecks: Int = 0
 
@@ -55,7 +56,6 @@ class FullScanStateService(val project: Project) {
         frameworkScansFinishedWithErrors[framework] = scanTaskResult
         project.service<AnalyticsService>().fullScanFrameworkError(framework)
         fullScanFinishedFrameworksNumber++
-
     }
 
     fun parsingErrorsFoundInFiles(framework: String, failedFilesSize: Int) {
@@ -63,9 +63,14 @@ class FullScanStateService(val project: Project) {
         project.service<AnalyticsService>().fullScanParsingError(framework, failedFilesSize)
     }
 
+    fun frameworkWasNotScanned(framework: String) {
+        unscannedFrameworks.add(framework)
+        fullScanFinishedFrameworksNumber++
+    }
+
     fun displayNotificationForFullScanSummary() {
         val totalErrors = project.service<ResultsCacheService>().getAllCheckovResults().size
-        val message = "Checkov has detected $totalErrors configuration errors in your project.\n" +
+        var message = "Checkov has detected $totalErrors configuration errors in your project.\n" +
                 "Check out the tool window to analyze your code.\n" +
                 "${DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN} frameworks were scanned:\n" +
                 "Scans for frameworks ${frameworkScansFinishedWithErrors.keys} were finished with errors.\n" +
@@ -74,7 +79,12 @@ class FullScanStateService(val project: Project) {
                         "log file - ${scanResults.debugOutput.path}\n" +
                         "checkov result - ${scanResults.checkovResult.path}\n" }}]\n" +
                 "${invalidFilesSize}} files were detected as invalid:\n" +
-                "No errors have been detected for frameworks $frameworkScansFinishedWithNoVulnerabilities :)"
+                "No errors have been detected for frameworks $frameworkScansFinishedWithNoVulnerabilities :)\n"
+
+        if (unscannedFrameworks.isNotEmpty()) {
+            message += "Frameworks $unscannedFrameworks were not scanned because they are probably not installed.\n"
+
+        }
 
         CheckovNotificationBalloon.showNotification(project,
                 message,

--- a/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
@@ -35,14 +35,7 @@ class FullScanStateService(val project: Project) {
     fun frameworkScanFinishedAndDetectedIssues(framework: String, numberOfIssues: Int) {
         project.service<AnalyticsService>().fullScanFrameworkDetectedVulnerabilities(framework, numberOfIssues)
 
-//        project.service<AnalyticsService>().fullScanByFrameworkFinished(framework)
         fullScanFinishedFrameworksNumber++
-//        if (fullScanFinishedFrameworksNumber == DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN) {
-////            val totalErrors = project.service<ResultsCacheService>().getAllCheckovResults().size
-////            val message = "Checkov has detected $totalErrors configuration errors in your project. Check out the tool window to analyze your code"
-////            CheckovNotificationBalloon.showNotification(project, message, NotificationType.INFORMATION)
-//            project.service<AnalyticsService>().fullScanFinished()
-//        }
     }
 
     fun frameworkFinishedWithNoErrors(framework: String) {

--- a/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
@@ -24,12 +24,14 @@ class FullScanStateService(val project: Project) {
     var frameworkScansFinishedWithErrors = mutableMapOf<String, ScanTaskResult>()
     var invalidFiles = mutableSetOf<String>()
     var frameworkScansFinishedWithNoVulnerabilities = mutableSetOf<String>()
+    var totalPassed: Int = 0
+    var totalFailed: Int = 0
 
     fun fullScanStarted() {
         fullScanFinishedFrameworksNumber = 0
     }
 
-    fun frameworkScanFinishedAndDetectedIssues(framework: String) {
+    fun frameworkScanFinishedAndDetectedIssues() {
 //        project.service<AnalyticsService>().fullScanByFrameworkFinished(framework)
         fullScanFinishedFrameworksNumber++
 //        if (fullScanFinishedFrameworksNumber == DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN) {

--- a/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
@@ -10,21 +10,72 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 
 @Service
-class FullScanStateService {
-    private var fullScanFinishedFrameworksNumber = 0
+class FullScanStateService(val project: Project) {
+    private var fullScanFinishedFrameworksNumber: Int = 0
+        set(value) {
+            field = value
+            if (value == DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN) {
+                project.service<AnalyticsService>().fullScanFinished()
+                displayNotificationForFullScanSummary()
+            }
+
+        }
+
+    var frameworkScansFinishedWithErrors = mutableMapOf<String, ScanTaskResult>()
+    var invalidFiles = mutableSetOf<String>()
+    var frameworkScansFinishedWithNoVulnerabilities = mutableSetOf<String>()
 
     fun fullScanStarted() {
         fullScanFinishedFrameworksNumber = 0
     }
 
-    fun fullScanFrameworkFinished(project: Project, framework: String) {
-        project.service<AnalyticsService>().fullScanByFrameworkFinished(framework)
+    fun frameworkScanFinishedAndDetectedIssues(framework: String) {
+//        project.service<AnalyticsService>().fullScanByFrameworkFinished(framework)
         fullScanFinishedFrameworksNumber++
-        if (fullScanFinishedFrameworksNumber == DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN) {
-            val totalErrors = project.service<ResultsCacheService>().getAllCheckovResults().size
-            val errorMessage = "Checkov has detected $totalErrors configuration errors in your project. Check out the tool window to analyze your code"
-            CheckovNotificationBalloon.showNotification(project, errorMessage, NotificationType.INFORMATION)
-            project.service<AnalyticsService>().fullScanFinished()
-        }
+//        if (fullScanFinishedFrameworksNumber == DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN) {
+////            val totalErrors = project.service<ResultsCacheService>().getAllCheckovResults().size
+////            val message = "Checkov has detected $totalErrors configuration errors in your project. Check out the tool window to analyze your code"
+////            CheckovNotificationBalloon.showNotification(project, message, NotificationType.INFORMATION)
+//            project.service<AnalyticsService>().fullScanFinished()
+//        }
+    }
+
+    fun frameworkFinishedWithNoErrors(framework: String) {
+        frameworkScansFinishedWithNoVulnerabilities.add(framework)
+        project.service<AnalyticsService>().fullScanFrameworkFinishedNoErrors(framework)
+        fullScanFinishedFrameworksNumber++
+
+    }
+
+    fun frameworkFinishedWithErrors(framework: String, scanTaskResult: ScanTaskResult) {
+        frameworkScansFinishedWithErrors[framework] = scanTaskResult
+        project.service<AnalyticsService>().fullScanFrameworkError(framework)
+        fullScanFinishedFrameworksNumber++
+
+    }
+
+    fun parsingErrorsFoundInFiles(framework: String, failedFiles: List<String>) {
+        invalidFiles.addAll(failedFiles)
+        project.service<AnalyticsService>().fullScanParsingError(framework, failedFiles)
+    }
+
+    fun displayNotificationForFullScanSummary() {
+        val totalErrors = project.service<ResultsCacheService>().getAllCheckovResults().size
+        val message = "Checkov has detected $totalErrors configuration errors in your project.\n" +
+                "Check out the tool window to analyze your code.\n" +
+                "${DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN} frameworks were scanned:\n" +
+                "Scans for frameworks ${frameworkScansFinishedWithErrors.keys} were finished with errors.\n" +
+                "Please check the log files in:\n" +
+                "[${frameworkScansFinishedWithErrors.map { (framework, scanResults) -> "$framework:\n" +
+                        "log file - ${scanResults.debugOutput.path}\n" +
+                        "checkov result - ${scanResults.checkovResult.path}\n" }}]\n" +
+                "${invalidFiles.size} files were detected as invalid:\n" +
+                "[${invalidFiles.joinToString { ",\n" }}]\n" +
+                "No errors have been detected for frameworks $frameworkScansFinishedWithNoVulnerabilities :)"
+
+        CheckovNotificationBalloon.showNotification(project,
+                message,
+                NotificationType.INFORMATION)
+
     }
 }

--- a/src/main/kotlin/com/bridgecrew/services/scan/ScanTask.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/ScanTask.kt
@@ -1,7 +1,6 @@
 package com.bridgecrew.services.scan
 
 import com.bridgecrew.analytics.AnalyticsService
-import com.bridgecrew.errors.CheckovErrorHandlerService
 import com.bridgecrew.utils.DEFAULT_TIMEOUT
 import com.bridgecrew.utils.extractFileNameFromPath
 import com.intellij.execution.ExecutionException
@@ -15,7 +14,6 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
-import com.intellij.workspaceModel.ide.impl.jps.serialization.FileInDirectorySourceNames
 import java.io.File
 
 data class ScanTaskResult(
@@ -29,37 +27,9 @@ abstract class ScanTask(project: Project, title: String, private val sourceName:
 
     protected val LOG = logger<ScanTask>()
 
-//    private val sourceName = if (scanSourceType == CheckovScanService.ScanSourceType.FILE) {
-//        extractFileNameFromPath(scanSource)
-//    } else scanSource
     val checkovResultFile: File = File.createTempFile("${sourceName}-checkov-result", ".tmp")
     val debugOutputFile: File = File.createTempFile("${sourceName}-debug-output", ".tmp")
     var errorReason = ""
-
-//    override fun run(indicator: ProgressIndicator) {
-//        try {
-//            LOG.info("Going to scan for ${scanSourceType.toString().lowercase()} $scanSource")
-//            indicator.isIndeterminate = false
-//
-//            val scanTaskResult: ScanTaskResult = getScanOutputs()
-//
-//            LOG.info("Checkov scan task finished successfully for ${scanSourceType.toString().lowercase()} $scanSource")
-//
-//            if (scanSourceType == CheckovScanService.ScanSourceType.FRAMEWORK) {
-//                project.service<AnalyticsService>().fullScanByFrameworkFinished(scanSource)
-//            }
-//            project.service<CheckovScanService>().analyzeScan(scanTaskResult, processHandler.exitCode!!, project, scanSource, scanSourceType)
-//
-//        } catch (error: Exception) {
-//            LOG.error("error while scanning ${scanSourceType.toString().lowercase()} $scanSource", error)
-//            if (scanSourceType == CheckovScanService.ScanSourceType.FRAMEWORK) {
-//                project.service<FullScanStateService>().fullScanFrameworkFinished(project, scanSource)
-//                project.service<FullScanStateService>().frameworkFinishedWithErrors(scanSource, ScanTaskResult(checkovResultFile, debugOutputFile, errorReason))
-//            }
-//            throw error
-//        }
-//
-//    }
 
     protected fun getScanOutputs(): ScanTaskResult {
         LOG.assertTrue(!processHandler.isStartNotified)
@@ -123,7 +93,6 @@ abstract class ScanTask(project: Project, title: String, private val sourceName:
                 LOG.error("error while scanning framework $framework", error)
                 project.service<AnalyticsService>().fullScanByFrameworkFinished(framework)
 
-//                project.service<FullScanStateService>().fullScanFrameworkFinished(framework)
                 project.service<FullScanStateService>().frameworkFinishedWithErrors(framework, ScanTaskResult(checkovResultFile, debugOutputFile, errorReason))
                 throw error
             }

--- a/src/main/kotlin/com/bridgecrew/services/scan/ScanTask.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/ScanTask.kt
@@ -1,5 +1,7 @@
 package com.bridgecrew.services.scan
 
+import com.bridgecrew.analytics.AnalyticsService
+import com.bridgecrew.errors.CheckovErrorHandlerService
 import com.bridgecrew.utils.DEFAULT_TIMEOUT
 import com.bridgecrew.utils.extractFileNameFromPath
 import com.intellij.execution.ExecutionException
@@ -13,8 +15,8 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.workspaceModel.ide.impl.jps.serialization.FileInDirectorySourceNames
 import java.io.File
-import java.util.*
 
 data class ScanTaskResult(
         val checkovResult: File,
@@ -22,32 +24,44 @@ data class ScanTaskResult(
         val errorReason: String
 )
 
-class ScanTask(project: Project, title: String, private val scanSource: String, private val processHandler: ProcessHandler, private val scanSourceType: CheckovScanService.ScanSourceType) :
+abstract class ScanTask(project: Project, title: String, private val sourceName: String, private val processHandler: ProcessHandler, private val scanSourceType: CheckovScanService.ScanSourceType) :
         Task.Backgroundable(project, title, true) {
 
-    private val LOG = logger<ScanTask>()
+    protected val LOG = logger<ScanTask>()
 
-    private val sourceName = if (scanSourceType == CheckovScanService.ScanSourceType.FILE) { extractFileNameFromPath(scanSource) } else scanSource
+//    private val sourceName = if (scanSourceType == CheckovScanService.ScanSourceType.FILE) {
+//        extractFileNameFromPath(scanSource)
+//    } else scanSource
     val checkovResultFile: File = File.createTempFile("${sourceName}-checkov-result", ".tmp")
     val debugOutputFile: File = File.createTempFile("${sourceName}-debug-output", ".tmp")
     var errorReason = ""
-    //    val checkovOutputBuilder = StringBuilder()
-//    val debugOutputBuilder = StringBuilder()
-    override fun run(indicator: ProgressIndicator) {
-        LOG.info("Going to scan for ${scanSourceType.toString().lowercase()} $scanSource")
-        indicator.isIndeterminate = false
 
-        val scanTaskResult: ScanTaskResult = getScanOutputs()
+//    override fun run(indicator: ProgressIndicator) {
+//        try {
+//            LOG.info("Going to scan for ${scanSourceType.toString().lowercase()} $scanSource")
+//            indicator.isIndeterminate = false
+//
+//            val scanTaskResult: ScanTaskResult = getScanOutputs()
+//
+//            LOG.info("Checkov scan task finished successfully for ${scanSourceType.toString().lowercase()} $scanSource")
+//
+//            if (scanSourceType == CheckovScanService.ScanSourceType.FRAMEWORK) {
+//                project.service<AnalyticsService>().fullScanByFrameworkFinished(scanSource)
+//            }
+//            project.service<CheckovScanService>().analyzeScan(scanTaskResult, processHandler.exitCode!!, project, scanSource, scanSourceType)
+//
+//        } catch (error: Exception) {
+//            LOG.error("error while scanning ${scanSourceType.toString().lowercase()} $scanSource", error)
+//            if (scanSourceType == CheckovScanService.ScanSourceType.FRAMEWORK) {
+//                project.service<FullScanStateService>().fullScanFrameworkFinished(project, scanSource)
+//                project.service<FullScanStateService>().frameworkFinishedWithErrors(scanSource, ScanTaskResult(checkovResultFile, debugOutputFile, errorReason))
+//            }
+//            throw error
+//        }
+//
+//    }
 
-        LOG.info("Checkov scan task finished successfully for ${scanSourceType.toString().lowercase()} $scanSource")
-
-        if (scanSourceType == CheckovScanService.ScanSourceType.FRAMEWORK) {
-            project.service<CheckovScanService>().analyzeScan(scanTaskResult, processHandler.exitCode!!, project, scanSource, scanSourceType)
-        }
-
-    }
-
-    private fun getScanOutputs(): ScanTaskResult {
+    protected fun getScanOutputs(): ScanTaskResult {
         LOG.assertTrue(!processHandler.isStartNotified)
 
         processHandler.addProcessListener(object : ProcessAdapter() {
@@ -79,9 +93,60 @@ class ScanTask(project: Project, title: String, private val scanSource: String, 
     }
 
     private fun updateErrorReason(text: String): String {
-        if ((text.contains("[ERROR]") || text.contains("Please check your API token") && !text.contains("Please check your API token"))) {
+       if (text.contains("[ERROR]")) {
+           return text.substring(text.indexOf("ERROR"))
+       }
+
+        if (text.contains("Please check your API token")) {
             return text
         }
+
         return ""
+    }
+
+    class FrameworkScanTask(project: Project, title: String, private val framework: String, private val processHandler: ProcessHandler):
+            ScanTask(project, title, framework, processHandler, CheckovScanService.ScanSourceType.FRAMEWORK) {
+        override fun run(indicator: ProgressIndicator) {
+            try {
+                LOG.info("Going to scan for framework $framework")
+                indicator.isIndeterminate = false
+
+                val scanTaskResult: ScanTaskResult = getScanOutputs()
+
+                LOG.info("Checkov scan task finished successfully for framework $framework")
+
+                project.service<AnalyticsService>().fullScanByFrameworkFinished(framework)
+
+                project.service<CheckovScanService>().analyzeScan(scanTaskResult, processHandler.exitCode!!, project, framework, CheckovScanService.ScanSourceType.FRAMEWORK)
+
+            } catch (error: Exception) {
+                LOG.error("error while scanning framework $framework", error)
+                project.service<AnalyticsService>().fullScanByFrameworkFinished(framework)
+
+//                project.service<FullScanStateService>().fullScanFrameworkFinished(framework)
+                project.service<FullScanStateService>().frameworkFinishedWithErrors(framework, ScanTaskResult(checkovResultFile, debugOutputFile, errorReason))
+                throw error
+            }
+        }
+    }
+
+    class FileScanTask(project: Project, title: String, private val filePath: String, private val processHandler: ProcessHandler):
+            ScanTask(project, title, extractFileNameFromPath(filePath), processHandler, CheckovScanService.ScanSourceType.FILE) {
+        override fun run(indicator: ProgressIndicator) {
+            try {
+                LOG.info("Going to scan for framework $filePath")
+                indicator.isIndeterminate = false
+
+                val scanTaskResult: ScanTaskResult = getScanOutputs()
+
+                LOG.info("Checkov scan task finished successfully for file $filePath")
+
+                project.service<CheckovScanService>().analyzeScan(scanTaskResult, processHandler.exitCode!!, project, filePath, CheckovScanService.ScanSourceType.FRAMEWORK)
+
+            } catch (error: Exception) {
+                LOG.error("error while scanning file $filePath", error)
+                throw error
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/bridgecrew/services/scan/ScanTask.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/ScanTask.kt
@@ -117,7 +117,7 @@ abstract class ScanTask(project: Project, title: String, private val sourceName:
 
                 project.service<AnalyticsService>().fullScanByFrameworkFinished(framework)
 
-                project.service<CheckovScanService>().analyzeScan(scanTaskResult, processHandler.exitCode!!, project, framework, CheckovScanService.ScanSourceType.FRAMEWORK)
+                project.service<CheckovScanService>().analyzeFrameworkScan(scanTaskResult, processHandler.exitCode!!, project, framework)
 
             } catch (error: Exception) {
                 LOG.error("error while scanning framework $framework", error)
@@ -141,7 +141,7 @@ abstract class ScanTask(project: Project, title: String, private val sourceName:
 
                 LOG.info("Checkov scan task finished successfully for file $filePath")
 
-                project.service<CheckovScanService>().analyzeScan(scanTaskResult, processHandler.exitCode!!, project, filePath, CheckovScanService.ScanSourceType.FRAMEWORK)
+                project.service<CheckovScanService>().analyzeFileScan(scanTaskResult, processHandler.exitCode!!, project, filePath)
 
             } catch (error: Exception) {
                 LOG.error("error while scanning file $filePath", error)

--- a/src/main/kotlin/com/bridgecrew/services/scan/ScanTask.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/ScanTask.kt
@@ -1,0 +1,87 @@
+package com.bridgecrew.services.scan
+
+import com.bridgecrew.utils.DEFAULT_TIMEOUT
+import com.bridgecrew.utils.extractFileNameFromPath
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.process.ProcessAdapter
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.ProcessOutputTypes
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import java.io.File
+import java.util.*
+
+data class ScanTaskResult(
+        val checkovResult: File,
+        val debugOutput: File,
+        val errorReason: String
+)
+
+class ScanTask(project: Project, title: String, private val scanSource: String, private val processHandler: ProcessHandler, private val scanSourceType: CheckovScanService.ScanSourceType) :
+        Task.Backgroundable(project, title, true) {
+
+    private val LOG = logger<ScanTask>()
+
+    private val sourceName = if (scanSourceType == CheckovScanService.ScanSourceType.FILE) { extractFileNameFromPath(scanSource) } else scanSource
+    val checkovResultFile: File = File.createTempFile("${sourceName}-checkov-result", ".tmp")
+    val debugOutputFile: File = File.createTempFile("${sourceName}-debug-output", ".tmp")
+    var errorReason = ""
+    //    val checkovOutputBuilder = StringBuilder()
+//    val debugOutputBuilder = StringBuilder()
+    override fun run(indicator: ProgressIndicator) {
+        LOG.info("Going to scan for ${scanSourceType.toString().lowercase()} $scanSource")
+        indicator.isIndeterminate = false
+
+        val scanTaskResult: ScanTaskResult = getScanOutputs()
+
+        LOG.info("Checkov scan task finished successfully for ${scanSourceType.toString().lowercase()} $scanSource")
+
+        if (scanSourceType == CheckovScanService.ScanSourceType.FRAMEWORK) {
+            project.service<CheckovScanService>().analyzeScan(scanTaskResult, processHandler.exitCode!!, project, scanSource, scanSourceType)
+        }
+
+    }
+
+    private fun getScanOutputs(): ScanTaskResult {
+        LOG.assertTrue(!processHandler.isStartNotified)
+
+        processHandler.addProcessListener(object : ProcessAdapter() {
+
+            override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+                if (outputType == ProcessOutputTypes.SYSTEM) {
+                    return
+                }
+
+                val text = event.text
+
+                if (outputType == ProcessOutputTypes.STDOUT) {
+                    checkovResultFile.appendText(text)
+                } else if (outputType == ProcessOutputTypes.STDERR) {
+                    debugOutputFile.appendText(text)
+                    errorReason = updateErrorReason(text)
+                }
+
+                LOG.debug(text)
+            }
+        })
+
+        processHandler.startNotify()
+        if (!processHandler.waitFor(DEFAULT_TIMEOUT)) {
+            throw ExecutionException("Script execution took more than ${(DEFAULT_TIMEOUT / 1000)} seconds")
+        }
+
+        return ScanTaskResult(checkovResultFile, debugOutputFile, errorReason)
+    }
+
+    private fun updateErrorReason(text: String): String {
+        if ((text.contains("[ERROR]") || text.contains("Please check your API token") && !text.contains("Please check your API token"))) {
+            return text
+        }
+        return ""
+    }
+}

--- a/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowManagerPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowManagerPanel.kt
@@ -10,7 +10,7 @@ import com.bridgecrew.ui.topPanel.CheckovTopPanel
 import com.bridgecrew.ui.vulnerabilitiesTree.CheckovToolWindowTree
 import com.bridgecrew.utils.FULL_SCAN_EXCLUDED_PATHS
 import com.bridgecrew.utils.PANELTYPE
-import com.bridgecrew.utils.addLogsDirectoryToGitIgnore
+//import com.bridgecrew.utils.addLogsDirectoryToGitIgnore
 import com.bridgecrew.utils.getGitIgnoreValues
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -87,7 +87,7 @@ class CheckovToolWindowManagerPanel(val project: Project) : SimpleToolWindowPane
     }
 
     fun subscribeToProjectEventChange() {
-        addLogsDirectoryToGitIgnore(project)
+//        addLogsDirectoryToGitIgnore(project)
         if (SwingUtilities.isEventDispatchThread()) {
             project.service<CheckovToolWindowManagerPanel>().loadMainPanel()
         } else {

--- a/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowManagerPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowManagerPanel.kt
@@ -107,6 +107,10 @@ class CheckovToolWindowManagerPanel(val project: Project) : SimpleToolWindowPane
         // subscribe to update file events
         project.messageBus.connect().subscribe(VirtualFileManager.VFS_CHANGES, object : BulkFileListener {
             override fun after(events: MutableList<out VFileEvent>) {
+                if (events.isEmpty()) {
+                    return
+                }
+
                 LOG.debug("file event for file: ${events[0].file!!.path}. isValid: ${events[0].isValid}, isFromRefresh: ${events[0].isFromRefresh}, isFromSave: ${events[0].isFromSave}, requestor: ${events[0].requestor}")
 
                 if (events.isEmpty() || !events[0].isFromSave || events[0].file == null) {

--- a/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowManagerPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowManagerPanel.kt
@@ -10,7 +10,6 @@ import com.bridgecrew.ui.topPanel.CheckovTopPanel
 import com.bridgecrew.ui.vulnerabilitiesTree.CheckovToolWindowTree
 import com.bridgecrew.utils.FULL_SCAN_EXCLUDED_PATHS
 import com.bridgecrew.utils.PANELTYPE
-//import com.bridgecrew.utils.addLogsDirectoryToGitIgnore
 import com.bridgecrew.utils.getGitIgnoreValues
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -87,7 +86,6 @@ class CheckovToolWindowManagerPanel(val project: Project) : SimpleToolWindowPane
     }
 
     fun subscribeToProjectEventChange() {
-//        addLogsDirectoryToGitIgnore(project)
         if (SwingUtilities.isEventDispatchThread()) {
             project.service<CheckovToolWindowManagerPanel>().loadMainPanel()
         } else {

--- a/src/main/kotlin/com/bridgecrew/ui/topPanel/CheckovTopPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/topPanel/CheckovTopPanel.kt
@@ -72,7 +72,7 @@ class CheckovTopPanel(val project: Project) : SimpleToolWindowPanel(true, true),
             val startedTime = if (fullScanAnalyticsData.isFullScanStarted()) fullScanAnalyticsData.scanStartedTime.toInstant() else now
             val finishedTime = if (fullScanAnalyticsData.isFullScanFinished()) fullScanAnalyticsData.scanFinishedTime.toInstant() else now
             val totalScanTimeDuration = Duration.between(startedTime, finishedTime)
-            ScanResultMetadata(totalIssues = project.service<FullScanStateService>().totalFailed, totalPassed = project.service<FullScanStateService>().totalPassed, scanDuration = totalScanTimeDuration.toSeconds())
+            ScanResultMetadata(totalIssues = project.service<FullScanStateService>().totalFailedCheckovChecks, totalPassed = project.service<FullScanStateService>().totalPassedCheckovChecks, scanDuration = totalScanTimeDuration.toSeconds())
         } else {
             ScanResultMetadata(totalIssues = 0, totalPassed = 0, scanDuration = 0)
         }

--- a/src/main/kotlin/com/bridgecrew/ui/topPanel/CheckovTopPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/topPanel/CheckovTopPanel.kt
@@ -1,6 +1,7 @@
 package com.bridgecrew.ui.topPanel
 
 import com.bridgecrew.analytics.AnalyticsService
+import com.bridgecrew.services.scan.FullScanStateService
 import com.bridgecrew.ui.actions.SeverityFilterActions
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
@@ -65,13 +66,13 @@ class CheckovTopPanel(val project: Project) : SimpleToolWindowPanel(true, true),
     }
 
     private fun getScanResultMetadata(): ScanResultMetadata {
-        val fullScanData = project.service<AnalyticsService>().getFullScanData()
-        val scanResultMetadata: ScanResultMetadata = if (fullScanData != null) {
+        val fullScanAnalyticsData: AnalyticsService.FullScanAnalyticsData? = project.service<AnalyticsService>().fullScanData
+        val scanResultMetadata: ScanResultMetadata = if (fullScanAnalyticsData != null) {
             val now = Instant.now()
-            val startedTime = if (fullScanData.isFullScanStarted()) fullScanData.fullScanStartedTime.toInstant() else now
-            val finishedTime = if (fullScanData.isFullScanFinished()) fullScanData.fullScanFinishedTime.toInstant() else now
+            val startedTime = if (fullScanAnalyticsData.isFullScanStarted()) fullScanAnalyticsData.scanStartedTime.toInstant() else now
+            val finishedTime = if (fullScanAnalyticsData.isFullScanFinished()) fullScanAnalyticsData.scanFinishedTime.toInstant() else now
             val totalScanTimeDuration = Duration.between(startedTime, finishedTime)
-            ScanResultMetadata(totalIssues = fullScanData.totalFailed, totalPassed = fullScanData.totalPassed, scanDuration = totalScanTimeDuration.toSeconds())
+            ScanResultMetadata(totalIssues = project.service<FullScanStateService>().totalFailed, totalPassed = project.service<FullScanStateService>().totalPassed, scanDuration = totalScanTimeDuration.toSeconds())
         } else {
             ScanResultMetadata(totalIssues = 0, totalPassed = 0, scanDuration = 0)
         }

--- a/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
@@ -88,11 +88,6 @@ class CheckovUtils {
         private fun extractParsingErrors(summary: JSONObject): Int {
             try {
                 return summary.getInt("parsing_errors")
-//                if (parsingErrorSummary > 0) {
-//                    val parsingErrorsList = object : TypeToken<List<String>>() {}.type
-//
-//                    return listOf() // TODO - after getting the correct fields from checkov - gson.fromJson(results.getJSONArray("parsing_errors").toString(), parsingErrorsList)
-//                }
             } catch (e: Exception) {
                 LOG.error("Error while extracting parsing errors", e)
             }

--- a/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
@@ -89,7 +89,7 @@ class CheckovUtils {
                 if (parsingErrorSummary > 0) {
                     val parsingErrorsList = object : TypeToken<List<String>>() {}.type
 
-                    return gson.fromJson(results.getJSONArray("parsing_errors").toString(), parsingErrorsList)
+                    return listOf() // TODO - after getting the correct fields from checkov - gson.fromJson(results.getJSONArray("parsing_errors").toString(), parsingErrorsList)
                 }
             } catch (e: Exception) {
                 LOG.error("Error while extracting parsing errors", e)

--- a/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
@@ -25,20 +25,9 @@ class CheckovUtils {
                 return CheckovResultExtractionData(arrayListOf(), arrayListOf())
 
             }
-            var checkovResult = "checkovResult"
-            val outputListOfLines = rawResult.split("\n").map { it.trim() }
-            for (i in outputListOfLines.indices) {
-                // filter lines that can appear in the Python version output, like '[GCC 10.2.1 20210110]'
-                if (!outputListOfLines[i].startsWith('{') && !outputListOfLines[i].startsWith('[') ||
-                        (outputListOfLines[i].startsWith("[") && outputListOfLines[i].endsWith("]"))) {
-                    continue
-                }
-                checkovResult = outputListOfLines.subList(i, outputListOfLines.size - 1).joinToString("\n")
-                break
-            }
 
-            LOG.info("found checkov result for source $scanningSource") // - $checkovResult")
-            checkovResult = checkovResult.replace("\u001B[0m", "")
+            LOG.info("found checkov result for source $scanningSource")
+            val checkovResult = rawResult.replace("\u001B[0m", "")
 
             return when (checkovResult[0]) {
                 '{' -> {

--- a/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
@@ -11,7 +11,7 @@ import org.json.JSONObject
 data class CheckovResultExtractionData(
         val failedChecks: List<CheckovResult> = arrayListOf(),
         val parsingErrors: List<String> = arrayListOf(),
-        val passedChecks: Int = 0
+        val passedChecksSize: Int = 0
 )
 
 class CheckovUtils {
@@ -45,7 +45,7 @@ class CheckovUtils {
                         val extractionResult = extractFailedChecksAndParsingErrorsFromObj(resultItem as JSONObject)
                         failedChecks.addAll(extractionResult.failedChecks)
                         parsingErrors.addAll(extractionResult.parsingErrors)
-                        passedChecks += extractionResult.passedChecks
+                        passedChecks += extractionResult.passedChecksSize
                     }
                     CheckovResultExtractionData(failedChecks, parsingErrors, passedChecks)
                 }

--- a/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
@@ -44,7 +44,7 @@ class CheckovUtils {
                     for (resultItem in resultsArray) {
                         val extractionResult = extractFailedChecksAndParsingErrorsFromObj(resultItem as JSONObject)
                         failedChecks.addAll(extractionResult.failedChecks)
-                        parsingErrors += extractionResult.passedChecksSize
+                        parsingErrors += extractionResult.parsingErrorsSize
                         passedChecks += extractionResult.passedChecksSize
                     }
                     CheckovResultExtractionData(failedChecks, parsingErrors, passedChecks)

--- a/src/main/kotlin/com/bridgecrew/utils/Constants.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/Constants.kt
@@ -12,7 +12,7 @@ object PANELTYPE {
     const val CHECKOV_INITIALIZATION_PROGRESS = 3
 }
 
-const val DEFAULT_TIMEOUT: Long = 180000
+const val DEFAULT_TIMEOUT: Long = 1800000
 
 const val GIT_DEFAULT_REPOSITORY_NAME = "jetbrains/extension"
 

--- a/src/main/kotlin/com/bridgecrew/utils/Constants.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/Constants.kt
@@ -39,4 +39,4 @@ enum class FileType {
     UNKNOWN
 }
 
-const val ERROR_LOG_DIR_PATH = "prisma/error/logs"
+//const val ERROR_LOG_DIR_PATH = "prisma/error/logs"

--- a/src/main/kotlin/com/bridgecrew/utils/Constants.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/Constants.kt
@@ -39,4 +39,3 @@ enum class FileType {
     UNKNOWN
 }
 
-//const val ERROR_LOG_DIR_PATH = "prisma/error/logs"

--- a/src/main/kotlin/com/bridgecrew/utils/fileUtils.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/fileUtils.kt
@@ -144,17 +144,3 @@ fun extractFileNameFromPath(filePath: String): String {
     val extension: String = FilenameUtils.getExtension(filename)
     return filename.removeSuffix(".$extension")
 }
-
-//fun addLogsDirectoryToGitIgnore(project: Project) {
-//    val file = File("${project.basePath}/.gitignore")
-//
-//    if (!file.exists()) {
-//        file.createNewFile()
-//        file.writeText(ERROR_LOG_DIR_PATH)
-//        return
-//    }
-//
-//    if (!file.readLines().any { line -> line.trim() == ERROR_LOG_DIR_PATH }) {
-//        file.appendText("\n${ERROR_LOG_DIR_PATH}\n")
-//    }
-//}

--- a/src/main/kotlin/com/bridgecrew/utils/fileUtils.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/fileUtils.kt
@@ -145,16 +145,16 @@ fun extractFileNameFromPath(filePath: String): String {
     return filename.removeSuffix(".$extension")
 }
 
-fun addLogsDirectoryToGitIgnore(project: Project) {
-    val file = File("${project.basePath}/.gitignore")
-
-    if (!file.exists()) {
-        file.createNewFile()
-        file.writeText(ERROR_LOG_DIR_PATH)
-        return
-    }
-
-    if (!file.readLines().any { line -> line.trim() == ERROR_LOG_DIR_PATH }) {
-        file.appendText("\n${ERROR_LOG_DIR_PATH}\n")
-    }
-}
+//fun addLogsDirectoryToGitIgnore(project: Project) {
+//    val file = File("${project.basePath}/.gitignore")
+//
+//    if (!file.exists()) {
+//        file.createNewFile()
+//        file.writeText(ERROR_LOG_DIR_PATH)
+//        return
+//    }
+//
+//    if (!file.readLines().any { line -> line.trim() == ERROR_LOG_DIR_PATH }) {
+//        file.appendText("\n${ERROR_LOG_DIR_PATH}\n")
+//    }
+//}


### PR DESCRIPTION
Main changes:
1. Merging the fix for reading and parsing Checkov result in https://github.com/bridgecrewio/checkov-jetbrains-ide/pull/185
2. Checkov result + logs are now being saved to a temp file, in case there is any error - this files will not be removed and the used will be notified that the logs can be found there.
3. Improved Analytics service to hold information only about scan time.
4. Moved other relevant information for FullScanState service.
5. Improved notification bubble - the used will be notified only on errors + a summary for the whole scan
6. Separated full scan and file scan tasks to 2 different tasks + 2 different analyze methods.
7. Scan tasked is being executed in Jetbrain's thread pool.