### PR TITLE
BCE- 16082 enable correct file types on supress for secrets

### DIFF
--- a/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowManagerPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowManagerPanel.kt
@@ -256,8 +256,8 @@ class CheckovToolWindowManagerPanel(val project: Project) : SimpleToolWindowPane
 
                     override fun scanningFinished(scanSourceType: CheckovScanService.ScanSourceType) {
                         ApplicationManager.getApplication().invokeLater {
+                            SeverityFilterActions.onScanFinishedForDisplayingResults(project)
                             if (scanSourceType == CheckovScanService.ScanSourceType.FILE) {
-                                SeverityFilterActions.onSingleFileScanFinished(project)
                                 project.service<CheckovToolWindowManagerPanel>().loadMainPanel(PANELTYPE.CHECKOV_FILE_SCAN_FINISHED)
                             } else {
                                 project.service<CheckovToolWindowManagerPanel>().loadMainPanel(PANELTYPE.CHECKOV_FRAMEWORK_SCAN_FINISHED)

--- a/src/main/kotlin/com/bridgecrew/ui/actions/SeverityFilterActions.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/actions/SeverityFilterActions.kt
@@ -40,7 +40,7 @@ class SeverityFilterActions(val project: Project) : ActionListener {
             updateEnabledSeverities(category, project)
         }
 
-        fun onSingleFileScanFinished(project: Project) {
+        fun onScanFinishedForDisplayingResults(project: Project) {
             updateEnabledSeverities(CheckovToolWindowFactory.lastSelectedCategory, project)
         }
 

--- a/src/main/kotlin/com/bridgecrew/ui/buttons/SuppressionButton.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/buttons/SuppressionButton.kt
@@ -28,18 +28,9 @@ class SuppressionButton(private var result: BaseCheckovResult): CheckovLinkButto
         isOpenDialog = true
     }
 
-    private val allowedFileType: Set<FileType> = setOf(
-            FileType.DOCKERFILE,
-            FileType.YAML,
-            FileType.TERRAFORM
-    )
 
     override fun actionPerformed(e: ActionEvent?) {
         val fileType = getFileType(result.filePath)
-        if(!allowedFileType.contains(fileType)) {
-            Messages.showInfoMessage("File type $fileType cannot be suppressed inline", "Prisma Cloud")
-            return
-        }
 
         val dialog = SuppressionDialog()
         if(isOpenDialog) {

--- a/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/CheckovDescriptionPanelTop.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/CheckovDescriptionPanelTop.kt
@@ -2,14 +2,13 @@ package com.bridgecrew.ui.rightPanel.topPanel
 
 import com.bridgecrew.results.BaseCheckovResult
 import com.bridgecrew.results.Severity
-import com.bridgecrew.utils.CheckovUtils
-import com.bridgecrew.utils.getSeverityIconBySeverity
-import com.bridgecrew.utils.isUrl
+import com.bridgecrew.ui.buttons.SuppressionButton
+import com.bridgecrew.utils.*
 import java.awt.BorderLayout
 import java.awt.Dimension
 import javax.swing.*
 
-open class CheckovDescriptionPanelTop : JPanel() {
+open class CheckovDescriptionPanelTop(val result: BaseCheckovResult) : JPanel() {
 
     init {
         layout = BorderLayout()
@@ -37,5 +36,12 @@ open class CheckovDescriptionPanelTop : JPanel() {
 
     fun isShowDocumentationButton(result: BaseCheckovResult): Boolean {
         return !CheckovUtils.isCustomPolicy(result) && result.guideline != null && isUrl(result.guideline)
+    }
+
+    fun createSuppressionButton(panel: JPanel) {
+        val fileType: FileType = getFileType(result.filePath)
+        if (SUPPRESSION_BUTTON_ALLOWED_FILE_TYPES.contains(fileType)) {
+            panel.add(SuppressionButton(result))
+        }
     }
 }

--- a/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/IacPanelTop.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/IacPanelTop.kt
@@ -3,11 +3,10 @@ package com.bridgecrew.ui.rightPanel.topPanel
 import com.bridgecrew.results.BaseCheckovResult
 import com.bridgecrew.ui.buttons.DocumentationButton
 import com.bridgecrew.ui.buttons.FixButton
-import com.bridgecrew.ui.buttons.SuppressionButton
 import java.awt.BorderLayout
 import javax.swing.JPanel
 
-class IacPanelTop(val result: BaseCheckovResult): CheckovDescriptionPanelTop() {
+class IacPanelTop(result: BaseCheckovResult): CheckovDescriptionPanelTop(result) {
 
     init {
         add(createTitleAndIcon(getTitle(result), result.severity), BorderLayout.WEST)
@@ -16,10 +15,12 @@ class IacPanelTop(val result: BaseCheckovResult): CheckovDescriptionPanelTop() {
 
     private fun createDescriptionPanelTitleActions(): JPanel {
         val panel = createActionsPanel()
-        if(isShowDocumentationButton(result)){
+        if (isShowDocumentationButton(result)) {
             panel.add(result.guideline?.let { DocumentationButton(it) })
         }
-        panel.add(SuppressionButton(result))
+
+        createSuppressionButton(panel)
+
         if(result.fixDefinition != null){
             panel.add(FixButton(result))
         }

--- a/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/LicensePanelTop.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/LicensePanelTop.kt
@@ -1,11 +1,10 @@
 package com.bridgecrew.ui.rightPanel.topPanel
 
 import com.bridgecrew.results.BaseCheckovResult
-import com.bridgecrew.ui.buttons.SuppressionButton
 import java.awt.BorderLayout
 import javax.swing.JPanel
 
-class LicensePanelTop(val result: BaseCheckovResult): CheckovDescriptionPanelTop() {
+class LicensePanelTop(result: BaseCheckovResult): CheckovDescriptionPanelTop(result) {
 
     init {
         add(createTitleAndIcon(result.name, result.severity), BorderLayout.WEST)
@@ -14,7 +13,7 @@ class LicensePanelTop(val result: BaseCheckovResult): CheckovDescriptionPanelTop
 
     private fun createDescriptionPanelTitleActions(): JPanel {
         val panel = createActionsPanel()
-        panel.add(SuppressionButton(result))
+        createSuppressionButton(panel)
         return panel
     }
 }

--- a/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/SecretsPanelTop.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/SecretsPanelTop.kt
@@ -3,10 +3,12 @@ package com.bridgecrew.ui.rightPanel.topPanel
 import com.bridgecrew.results.BaseCheckovResult
 import com.bridgecrew.ui.buttons.FixButton
 import com.bridgecrew.ui.buttons.SuppressionButton
+import com.bridgecrew.utils.FileType
+import com.bridgecrew.utils.getFileType
 import java.awt.BorderLayout
 import javax.swing.JPanel
 
-class SecretsPanelTop(val result: BaseCheckovResult): CheckovDescriptionPanelTop() {
+class SecretsPanelTop(result: BaseCheckovResult): CheckovDescriptionPanelTop(result) {
 
     init {
         add(createTitleAndIcon(result.name, result.severity), BorderLayout.WEST)
@@ -15,10 +17,19 @@ class SecretsPanelTop(val result: BaseCheckovResult): CheckovDescriptionPanelTop
 
     private fun createDescriptionPanelTitleActions(): JPanel {
         val panel = createActionsPanel()
-        panel.add(SuppressionButton(result))
-        if(result.fixDefinition != null){
+        if (shouldEnableSuppressionButton()) {
+            createSuppressionButton(panel)
+//            panel.add(SuppressionButton(result))
+        }
+        if (result.fixDefinition != null) {
             panel.add(FixButton(result))
         }
         return panel
+    }
+
+    // TODO - Other file types should be supported later, waiting for Secrets team to implement this logic, currently will be disabled for Alpha version
+    private fun shouldEnableSuppressionButton(): Boolean {
+        val fileType = getFileType(result.filePath)
+        return (fileType == FileType.TERRAFORM || fileType == FileType.YAML)
     }
 }

--- a/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/SecretsPanelTop.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/SecretsPanelTop.kt
@@ -19,7 +19,6 @@ class SecretsPanelTop(result: BaseCheckovResult): CheckovDescriptionPanelTop(res
         val panel = createActionsPanel()
         if (shouldEnableSuppressionButton()) {
             createSuppressionButton(panel)
-//            panel.add(SuppressionButton(result))
         }
         if (result.fixDefinition != null) {
             panel.add(FixButton(result))

--- a/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/VulnerabilitiesPanelTop.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/VulnerabilitiesPanelTop.kt
@@ -4,11 +4,10 @@ import com.bridgecrew.results.VulnerabilityCheckovResult
 import com.bridgecrew.ui.buttons.DocumentationButton
 import com.bridgecrew.ui.buttons.FixButton
 import com.bridgecrew.ui.buttons.FixCVEButton
-import com.bridgecrew.ui.buttons.SuppressionButton
 import java.awt.BorderLayout
 import javax.swing.JPanel
 
-class VulnerabilitiesPanelTop(val result: VulnerabilityCheckovResult): CheckovDescriptionPanelTop() {
+class VulnerabilitiesPanelTop(result: VulnerabilityCheckovResult): CheckovDescriptionPanelTop(result) {
 
     init {
         add(createTitleAndIcon(getTitle(result), result.severity), BorderLayout.WEST)
@@ -17,10 +16,12 @@ class VulnerabilitiesPanelTop(val result: VulnerabilityCheckovResult): CheckovDe
 
     private fun createDescriptionPanelTitleActions(): JPanel {
         val panel = createActionsPanel()
-        if(isShowDocumentationButton(result)){
+        if (isShowDocumentationButton(result)) {
             panel.add(result.guideline?.let { DocumentationButton(it) })
         }
-        panel.add(SuppressionButton(result))
+
+        createSuppressionButton(panel)
+
         if(result.fixDefinition != null){
             panel.add(FixCVEButton(result.id))
             panel.add(FixButton(result))

--- a/src/main/kotlin/com/bridgecrew/utils/Constants.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/Constants.kt
@@ -42,3 +42,8 @@ enum class FileType {
     UNKNOWN
 }
 
+val SUPPRESSION_BUTTON_ALLOWED_FILE_TYPES: Set<FileType> = setOf(
+        FileType.DOCKERFILE,
+        FileType.YAML,
+        FileType.TERRAFORM
+)


### PR DESCRIPTION
Display Suppression button for correct file types: dockerfile, terraform, yaml.
For secrets - display only for terraform and yaml.

Fixing a little bug for severity - load the buttons also when a framework is presenting the results