### PR TITLE
fix docker scanning

### DIFF
--- a/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/CheckovScanCommandsService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/CheckovScanCommandsService.kt
@@ -12,7 +12,7 @@ abstract class CheckovScanCommandsService(val project: Project) {
 
     fun getExecCommandForSingleFile(filePath: String, outputFilePath: String): ArrayList<String> {
         val cmds = ArrayList<String>()
-        cmds.addAll(getCheckovRunningCommandByServiceType())
+        cmds.addAll(getCheckovRunningCommandByServiceType(outputFilePath))
         cmds.addAll(getCheckovCliArgsForExecCommand(outputFilePath))
 
         cmds.add("-f")
@@ -23,7 +23,7 @@ abstract class CheckovScanCommandsService(val project: Project) {
     fun getExecCommandsForRepositoryByFramework(framework: String, outputFilePath: String): ArrayList<String> {
 
         val baseCmds = ArrayList<String>()
-        baseCmds.addAll(getCheckovRunningCommandByServiceType())
+        baseCmds.addAll(getCheckovRunningCommandByServiceType(outputFilePath))
 
         baseCmds.add("-d")
         baseCmds.add(getDirectory())
@@ -47,8 +47,10 @@ abstract class CheckovScanCommandsService(val project: Project) {
                     "Please insert an Api Token to continue")
         }
 
-        return arrayListOf("-s", "--bc-api-key", apiToken, "--repo-id", gitRepo, "--quiet", "-o", "cli", "-o", "json",
+        val command = arrayListOf("-s", "--bc-api-key", apiToken, "--repo-id", gitRepo, "--quiet", "-o", "cli", "-o", "json",
                 "--output-file-path", "console,$outputFilePath")
+        command.addAll(getCertParams())
+        return command
     }
 
     private fun getExcludePathCommand(): ArrayList<String> {
@@ -72,7 +74,19 @@ abstract class CheckovScanCommandsService(val project: Project) {
         return StringUtils.removeEnd(excludePath, "/")
     }
 
-    abstract fun getCheckovRunningCommandByServiceType(): ArrayList<String>
+    private fun getCertParams(): ArrayList<String> {
+        val cmds = ArrayList<String>()
+        val certPath = settings?.certificate
+        if (!certPath.isNullOrEmpty()) {
+            cmds.add("--ca-certificate")
+            cmds.add(getCertPath())
+            return cmds
+        }
+        return cmds
+    }
+
+    abstract fun getCheckovRunningCommandByServiceType(outputFilePath: String): ArrayList<String>
     abstract fun getDirectory(): String
     abstract fun getFilePath(originalFilePath: String): String
+    abstract fun getCertPath(): String
 }

--- a/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/DockerCheckovScanCommandsService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/DockerCheckovScanCommandsService.kt
@@ -8,8 +8,9 @@ import org.apache.commons.io.FilenameUtils
 class DockerCheckovScanCommandsService(project: Project) : CheckovScanCommandsService(project) {
 
     private val image = "bridgecrew/checkov"
-    private val volumeDirectory = "checkovScan"
-    override fun getCheckovRunningCommandByServiceType(): ArrayList<String> {
+    private val volumeDirectory = FilenameUtils.separatorsToUnix(project.basePath)
+    private val volumeCertPath = "/usr/lib/ssl/cert.pem"
+    override fun getCheckovRunningCommandByServiceType(outputFilePath: String): ArrayList<String> {
         val pluginVersion =
                 PluginManagerCore.getPlugin(PluginId.getId("com.github.bridgecrewio.checkov"))?.version ?: "UNKNOWN"
 
@@ -20,11 +21,14 @@ class DockerCheckovScanCommandsService(project: Project) : CheckovScanCommandsSe
             dockerCommand.addAll(arrayListOf("--env", "PRISMA_API_URL=${prismaUrl}"))
         }
 
-        if (certPath?.isNotEmpty() == true) {
-            var volumeCaFile = "$certPath:/usr/lib/ssl/cert.pem"
-            dockerCommand.addAll(arrayListOf("--volume", volumeCaFile, "--env", "SSL_CERT_FILE=/usr/lib/ssl/cert.pem", "--env", "REQUESTS_CA_BUNDLE=/usr/lib/ssl/cert.pem"))
+        if (!certPath.isNullOrEmpty()) {
+            var volumeCaFile = "$certPath:$volumeCertPath"
+            dockerCommand.addAll(arrayListOf("--volume", volumeCaFile))
         }
-        val volumeDir = "${FilenameUtils.separatorsToUnix(project.basePath!!)}:/${volumeDirectory}"
+
+        dockerCommand.addAll(arrayListOf("--volume", "$outputFilePath:$outputFilePath"))
+
+        val volumeDir = "${FilenameUtils.separatorsToUnix(project.basePath)}:/${volumeDirectory}"
         dockerCommand.addAll(arrayListOf("--volume", volumeDir, image))
         return dockerCommand
 
@@ -36,5 +40,9 @@ class DockerCheckovScanCommandsService(project: Project) : CheckovScanCommandsSe
 
     override fun getFilePath(originalFilePath: String): String {
         return originalFilePath.replace(project.basePath!!, volumeDirectory)
+    }
+
+    override fun getCertPath(): String {
+        return volumeCertPath
     }
 }

--- a/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/InstalledCheckovScanCommandsService.kt
+++ b/src/main/kotlin/com/bridgecrew/services/checkovScanCommandsService/InstalledCheckovScanCommandsService.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.project.Project
 import org.apache.commons.io.FilenameUtils
 
 class InstalledCheckovScanCommandsService(project: Project) : CheckovScanCommandsService(project) {
-    override fun getCheckovRunningCommandByServiceType(): ArrayList<String> {
+    override fun getCheckovRunningCommandByServiceType(outputFilePath: String): ArrayList<String> {
         return arrayListOf(project.service<CliService>().checkovPath)
     }
 
@@ -16,5 +16,9 @@ class InstalledCheckovScanCommandsService(project: Project) : CheckovScanCommand
 
     override fun getFilePath(originalFilePath: String): String {
         return FilenameUtils.separatorsToSystem(originalFilePath)
+    }
+
+    override fun getCertPath(): String {
+        return settings?.certificate!!
     }
 }

--- a/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
+++ b/src/main/kotlin/com/bridgecrew/services/scan/FullScanState.kt
@@ -146,14 +146,10 @@ class FullScanStateService(val project: Project) {
         val totalErrors = project.service<ResultsCacheService>().checkovResults.size
         var message = "Checkov has detected $totalErrors configuration errors in your project.\n" +
                 "Check out the tool window to analyze your code.\n" +
-                "${DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN} frameworks were scanned:\n" +
-                "Scans for frameworks ${frameworkScansFinishedWithErrors.keys} were finished with errors.\n" +
-                "Please check the log files in:\n" +
-                "[${frameworkScansFinishedWithErrors.map { (framework, scanResults) -> "$framework:\n" +
-                        "log file - ${scanResults.debugOutput.path}\n" +
-                        "checkov result - ${scanResults.checkovResult.path}\n" }}]\n" +
-                "${invalidFilesSize}} files were detected as invalid:\n" +
-                "No errors have been detected for frameworks $frameworkScansFinishedWithNoVulnerabilities :)\n"
+                "${DESIRED_NUMBER_OF_FRAMEWORK_FOR_FULL_SCAN} frameworks were scanned.\n" +
+                generateErrorMessageForFullScanSummary() +
+                generateInvalidFileSizeMessageForFullScanSummary() +
+                generateNoErrorsMessageForFullScanSummary()
 
         if (unscannedFrameworks.isNotEmpty()) {
             message += "Frameworks $unscannedFrameworks were not scanned because they are probably not installed.\n"
@@ -163,7 +159,34 @@ class FullScanStateService(val project: Project) {
         CheckovNotificationBalloon.showNotification(project,
                 message,
                 NotificationType.INFORMATION)
+    }
 
+    private fun generateErrorMessageForFullScanSummary(): String {
+        if (frameworkScansFinishedWithErrors.isEmpty()) {
+            return ""
+        }
+
+        return "Scans for frameworks ${frameworkScansFinishedWithErrors.keys} were finished with errors.\n" +
+                "Please check the log files in:\n" +
+                "[${frameworkScansFinishedWithErrors.map { (framework, scanResults) -> "$framework:\n" +
+                        "log file - ${scanResults.debugOutput.path}\n" +
+                        "checkov result - ${scanResults.checkovResult.path}\n" }}]\n"
+    }
+
+    private fun generateInvalidFileSizeMessageForFullScanSummary(): String {
+        if (invalidFilesSize == 0) {
+            return ""
+        }
+
+        return "${invalidFilesSize}} files were detected as invalid\n"
+    }
+
+    private fun generateNoErrorsMessageForFullScanSummary(): String {
+        if (frameworkScansFinishedWithNoVulnerabilities.isEmpty()) {
+            return ""
+        }
+
+        return "No errors have been detected for frameworks $frameworkScansFinishedWithNoVulnerabilities :)\n"
     }
 
     fun wereAllFrameworksFinished(): Boolean {

--- a/src/main/kotlin/com/bridgecrew/ui/CheckovSettingsPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/CheckovSettingsPanel.kt
@@ -17,7 +17,7 @@ class CheckovSettingsPanel(project: Project): JPanel() {
 
         layout = GridLayoutManager(3, 1, Insets(0, 0, 0, 0), -1, -1)
 
-        add(JLabel("Checkov Plugin would scan your infrastructure as code files."), createGridRowCol(0,0, GridConstraints.ANCHOR_CENTER))
+        add(JLabel("Prisma Cloud Plugin would scan your infrastructure as code files."), createGridRowCol(0,0, GridConstraints.ANCHOR_CENTER))
         add(JLabel("Please configure a valid Prisma token in order to use this Plugin"), createGridRowCol(1,0, GridConstraints.ANCHOR_CENTER))
         val settingsButton = JButton("Open Settings")
 

--- a/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowDescriptionPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/CheckovToolWindowDescriptionPanel.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.util.IconLoader
 import com.intellij.ui.ScrollPaneFactory
 import com.intellij.uiDesigner.core.GridConstraints
 import com.intellij.uiDesigner.core.GridLayoutManager
+import com.intellij.util.ui.JBUI
 import icons.CheckovIcons
 import java.awt.BorderLayout
 import java.awt.Dimension
@@ -62,10 +63,9 @@ class CheckovToolWindowDescriptionPanel(val project: Project) : SimpleToolWindow
     fun initializationDescription(): JPanel {
         descriptionPanel = JPanel()
         descriptionPanel.layout = GridLayoutManager(2, 1, Insets(0, 0, 0, 0), -1, -1)
-        val imagePanel = JPanel()
-        imagePanel.add(JLabel(IconLoader.getIcon("/icons/checkov_m.svg")), createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
+        val imagePanel = createImagePanel()
         val scanningPanel = JPanel()
-        scanningPanel.add(JLabel("Checkov is being initialized"),  createGridRowCol(1,0,GridConstraints.ANCHOR_NORTH))
+        scanningPanel.add(JLabel("Prisma Cloud is being initialized"),  createGridRowCol(1,0, GridConstraints.ANCHOR_NORTH))
         descriptionPanel.add(imagePanel, createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
         descriptionPanel.add(scanningPanel, createGridRowCol(1,0,GridConstraints.ANCHOR_NORTH))
         return descriptionPanel
@@ -74,12 +74,11 @@ class CheckovToolWindowDescriptionPanel(val project: Project) : SimpleToolWindow
     fun preScanDescription(): JPanel {
         descriptionPanel = JPanel()
         descriptionPanel.layout = GridLayoutManager(2, 1, Insets(0, 0, 0, 0), -1, -1)
-        val imagePanel = JPanel()
-        imagePanel.add(JLabel(IconLoader.getIcon("/icons/checkov_m.svg")), createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
+        val imagePanel = createImagePanel()
         val scanningPanel = JPanel()
         scanningPanel.layout = GridLayoutManager(2, 1, Insets(0, 0, 0, 0), -1, -1)
-        scanningPanel.add(JLabel("Checkov is ready to run."),  createGridRowCol(0,0,GridConstraints.ANCHOR_NORTH))
-        scanningPanel.add(JLabel("Scanning would start automatically once an IaC file is opened or saved"), createGridRowCol(1,0,GridConstraints.ANCHOR_NORTH))
+        scanningPanel.add(JLabel("Prisma Cloud is ready to run."),  createGridRowCol(0,0,GridConstraints.ANCHOR_NORTH))
+        scanningPanel.add(JLabel("Scanning would start automatically once a file is opened or saved"), createGridRowCol(1,0,GridConstraints.ANCHOR_NORTH))
         descriptionPanel.add(imagePanel, createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
         descriptionPanel.add(scanningPanel, createGridRowCol(1,0,GridConstraints.ANCHOR_NORTH))
         return descriptionPanel
@@ -88,8 +87,7 @@ class CheckovToolWindowDescriptionPanel(val project: Project) : SimpleToolWindow
     fun configurationDescription(): JPanel {
         descriptionPanel = JPanel()
         descriptionPanel.layout = GridLayoutManager(2, 1, Insets(0, 0, 0, 0), -1, -1)
-        val imagePanel = JPanel()
-        imagePanel.add(JLabel(IconLoader.getIcon("/icons/checkov_m.svg")))
+        val imagePanel = createImagePanel()
         val configPanel = JPanel()
         configPanel.add(CheckovSettingsPanel(project), GridConstraints.ANCHOR_CENTER)
         descriptionPanel.add(imagePanel, createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
@@ -100,8 +98,7 @@ class CheckovToolWindowDescriptionPanel(val project: Project) : SimpleToolWindow
     fun duringScanDescription(description: String): JPanel {
         descriptionPanel = JPanel()
         descriptionPanel.layout = GridLayoutManager(2, 1, Insets(0, 0, 0, 0), -1, -1)
-        val imagePanel = JPanel()
-        imagePanel.add(JLabel(IconLoader.getIcon("/icons/checkov_m.svg")), createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
+        val imagePanel = createImagePanel()
         val scanningPanel = JPanel()
         scanningPanel.add(JLabel(description), GridConstraints.ANCHOR_CENTER)
         descriptionPanel.add(imagePanel, createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
@@ -112,8 +109,7 @@ class CheckovToolWindowDescriptionPanel(val project: Project) : SimpleToolWindow
     fun failedScanDescription(): JPanel {
         descriptionPanel = JPanel()
         descriptionPanel.layout = GridLayoutManager(2, 1, Insets(0, 0, 0, 0), -1, -1)
-        val imagePanel = JPanel()
-        imagePanel.add(JLabel(IconLoader.getIcon("/icons/checkov_m.svg")), createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
+        val imagePanel = createImagePanel()
         val scanningPanel = JPanel()
         scanningPanel.add(JLabel("Scan failed to run, please check the logs for further action"), GridConstraints.ANCHOR_CENTER)
         descriptionPanel.add(imagePanel, createGridRowCol(0,0,GridConstraints.ANCHOR_NORTHEAST))
@@ -135,6 +131,15 @@ class CheckovToolWindowDescriptionPanel(val project: Project) : SimpleToolWindow
             ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
             ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED
         )
+    }
+
+    private fun createImagePanel(): JPanel {
+        val imagePanel = JPanel()
+        imagePanel.layout = GridLayoutManager(2, 2, JBUI.emptyInsets(), -1, -1)
+        imagePanel.add(JLabel(IconLoader.getIcon("/icons/plugin_large_icon.svg")), createGridRowCol(0,0, GridConstraints.ANCHOR_CENTER))
+        imagePanel.add(JLabel("Prisma Cloud"), createGridRowCol(1,0, GridConstraints.ANCHOR_NORTHEAST))
+        imagePanel.add(JLabel("  "), createGridRowCol(0,1, GridConstraints.ANCHOR_NORTHEAST))
+        return imagePanel
     }
 
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,7 @@
         <group id="com.bridgecrew.checkovScanActions">
             <action id="com.bridgecrew.ui.actions.CheckovScanAction"
                     class="com.bridgecrew.ui.actions.CheckovScanAction"
-                    text="Run Checkov Scan"/>
+                    text="Run Prisma Cloud Scan"/>
         </group>
     </actions>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,7 @@
         <toolWindow id="Prisma Code Security"
                     anchor="bottom"
                     factoryClass="com.bridgecrew.ui.CheckovToolWindowFactory"
-                    icon="/icons/checkov.svg"/>
+                    icon="/icons/plugin_small_icon.svg"/>
 
         <postStartupActivity implementation="com.bridgecrew.activities.PostStartupActivity"/>
 

--- a/src/main/resources/icons/plugin_large_icon.svg
+++ b/src/main/resources/icons/plugin_large_icon.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="21" viewBox="0 0 16 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10.609 13.8735V4.50406L15.5 13.8735H10.609ZM10.609 4.50406L5.71793 13.8735H10.609V20.6191L0.5 10.5001L5.66941 5.32353L6.4903 4.50406L10.609 0.381104V4.50406Z" fill="#7F8B91" fill-opacity="0.9"/>
+</svg>

--- a/src/main/resources/icons/plugin_small_icon.svg
+++ b/src/main/resources/icons/plugin_small_icon.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="15" viewBox="0 0 11 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.41324 9.89446V3.0235L11 9.89446H7.41324ZM7.41324 3.0235L3.82648 9.89446H7.41324V14.8412L0 7.42058L3.7909 3.62445L4.39288 3.0235L7.41324 0V3.0235Z" fill="#6E6E6E"/>
+</svg>


### PR DESCRIPTION
1. Fix docker scanning:
  1. `CheckovScanCommandsService.kt` - `--ca-certificate` - add arg for certificate path  map outputFilePath from local machine to container
  2. `DockerCheckovScanCommandsService.kt` - map certificate path, output file path and volume directory correctly
  3. `CheckovScanService.kt` - remove certificate generator function
2. `CheckovScanService.kt`, `CheckovSettingsPanel.kt`, `CheckovToolWindowDescriptionPanel.kt` - fix text and logos to Prisma Cloud
3. `FullScanState.kt` - improve summary logs 
