### PR TITLE
sca_image - fix title and fields in details view + fix tree

### DIFF
--- a/src/main/kotlin/com/bridgecrew/ui/rightPanel/dictionaryDetails/VulnerabilitiesDictionaryPanel.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/rightPanel/dictionaryDetails/VulnerabilitiesDictionaryPanel.kt
@@ -1,28 +1,50 @@
 package com.bridgecrew.ui.rightPanel.dictionaryDetails
 
+import com.bridgecrew.results.CheckType
 import com.bridgecrew.results.VulnerabilityCheckovResult
 
 class VulnerabilitiesDictionaryPanel(result: VulnerabilityCheckovResult): DictionaryExtraInfoPanel() {
 
-    override var fieldsMap: MutableMap<String, Any?> = mutableMapOf(
-            "Vulnerable Package" to result.packageName,
-            "Vulnerable Package Version" to result.packageVersion,
-            "Fixed Version" to result.fixVersion,
-            "Root Package" to result.rootPackageName,
-            "Root Package Version" to result.rootPackageVersion,
-            "Compliant Version (Fix all CVEs)" to result.rootPackageFixVersion,
-            "CVE ID" to result.violationId,
-            "CVSS" to result.cvss,
-            "Published" to result.publishedDate,
-            "Vector" to result.vector,
-            "Risk Factors" to result.riskFactors,
-            "Description" to result.description,
-            "Category" to result.category, // TODO - remove before release
-            "Check Type" to result.checkType.name.lowercase(), // TODO - remove before release
-    )
+    override var fieldsMap: MutableMap<String, Any?> = generateFieldsMap(result)
 
     init {
         addCustomPolicyGuidelinesIfNeeded(result)
         createDictionaryLayout()
+    }
+
+    private fun generateFieldsMap(result: VulnerabilityCheckovResult): MutableMap<String, Any?> {
+        val vulnerabilityFieldsMap: MutableMap<String, Any?> = mutableMapOf(
+        "Vulnerable Package" to result.packageName,
+        "Vulnerable Package Version" to result.packageVersion,
+        "Fixed Version" to result.fixVersion,
+        )
+
+        vulnerabilityFieldsMap.putAll(generateFieldsByCheckType(result))
+
+        vulnerabilityFieldsMap.putAll(mapOf(
+                       "CVE ID" to result.violationId,
+                       "CVSS" to result.cvss,
+                       "Published" to result.publishedDate,
+                       "Vector" to result.vector,
+                       "Risk Factors" to result.riskFactors,
+                       "Description" to result.description,
+                       "Category" to result.category, // TODO - remove before release
+                       "Check Type" to result.checkType.name.lowercase()) // TODO - remove before release
+        )
+
+        return vulnerabilityFieldsMap
+    }
+    private fun generateFieldsByCheckType(result: VulnerabilityCheckovResult): Map<String, String?> {
+        if (result.checkType == CheckType.SCA_IMAGE) {
+            return mapOf("Vulnerable Image" to result.resource)
+        }
+
+        if (result.checkType == CheckType.SCA_PACKAGE) {
+            return mapOf("Root Package" to result.rootPackageName,
+            "Root Package Version" to result.rootPackageVersion,
+            "Compliant Version (Fix all CVEs)" to result.rootPackageFixVersion)
+        }
+
+        return mapOf()
     }
 }

--- a/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/CheckovDescriptionPanelTop.kt
+++ b/src/main/kotlin/com/bridgecrew/ui/rightPanel/topPanel/CheckovDescriptionPanelTop.kt
@@ -23,7 +23,12 @@ open class CheckovDescriptionPanelTop(val result: BaseCheckovResult) : JPanel() 
     }
 
     fun getTitle(result: BaseCheckovResult): String {
-        if ((result.category == Category.VULNERABILITIES && result.checkType == CheckType.SCA_PACKAGE) || CheckovUtils.isCustomPolicy(result) ){
+        if (CheckovUtils.isCustomPolicy(result)) {
+            return name
+        }
+
+        if (result.category == Category.VULNERABILITIES &&
+                (result.checkType == CheckType.SCA_PACKAGE || result.checkType == CheckType.SCA_IMAGE)) {
             return result.name
         }
 

--- a/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
+++ b/src/main/kotlin/com/bridgecrew/utils/CheckovUtils.kt
@@ -56,11 +56,6 @@ class CheckovUtils {
                 return vulnerabilityResource
 
             return generateVulnerabilityResourceByPackage(vulnerabilityDetails.package_name, vulnerabilityDetails.package_version, result.resource)
-
-//            if (vulnerabilityResource != null)
-//                return vulnerabilityResource
-//
-//            return result.resource
         }
 
         private fun extractVulnerabilityImageResource(result: CheckovResult, vulnerabilityDetails: VulnerabilityDetails): String {


### PR DESCRIPTION
1. **Details view** - display `Vulnerable Image` field only in case of `sca_image`, display root package fields only in case of `sca_package`.
2. **Tree hierarchy** - for `sca_image` - group the vulnerable packages under a node of the vulnerable image: file -> vulnerable image -> vulnerable package + vulnerable package version + CVE

![Uploading image tree 2.png…]()
![Uploading image tree.png…]()
